### PR TITLE
feat : api 요청 형식 변경, AuthDto 추가, 회원 탈퇴 구현

### DIFF
--- a/src/main/java/com/project/mog/controller/users/UsersController.java
+++ b/src/main/java/com/project/mog/controller/users/UsersController.java
@@ -3,7 +3,9 @@ package com.project.mog.controller.users;
 import java.util.List;
 
 import org.springframework.http.HttpStatus;
+import org.springframework.http.HttpStatusCode;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -18,7 +20,7 @@ import com.project.mog.service.users.UsersService;
 import lombok.RequiredArgsConstructor;
 
 @RestController
-@RequestMapping("/api/users/")
+@RequestMapping("/api/v1/users/")
 @RequiredArgsConstructor
 public class UsersController {
 	private final UsersService usersService;
@@ -26,7 +28,6 @@ public class UsersController {
 	@GetMapping("list")
 	public ResponseEntity<List<UsersDto>> getAllUsers(){
 		List<UsersDto> users = usersService.getAllUsers();
-		System.out.println("users:"+users);
 		return ResponseEntity.ok(users);
 	}
 	
@@ -39,6 +40,11 @@ public class UsersController {
 	public ResponseEntity<UsersDto> getUser(@PathVariable Long usersId){
 		return usersService.getUser(usersId).map(ResponseEntity::ok).orElse(ResponseEntity.notFound().build());
 				
+	}
+	@DeleteMapping("/delete/{usersId}")
+	public ResponseEntity<UsersDto> deleteUser(@PathVariable Long usersId){
+		UsersDto deleteUsers = usersService.deleteUser(usersId);
+		return ResponseEntity.status(HttpStatus.OK).body(deleteUsers);
 	}
 	
 	

--- a/src/main/java/com/project/mog/repository/auth/AuthEntity.java
+++ b/src/main/java/com/project/mog/repository/auth/AuthEntity.java
@@ -1,0 +1,61 @@
+package com.project.mog.repository.auth;
+
+import java.time.LocalDateTime;
+
+import com.project.mog.repository.bios.BiosEntity;
+import com.project.mog.repository.users.UsersEntity;
+
+import jakarta.persistence.CascadeType;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.OneToOne;
+import jakarta.persistence.PrePersist;
+import jakarta.persistence.PreUpdate;
+import jakarta.persistence.SequenceGenerator;
+import jakarta.persistence.Table;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Entity
+@Table(name="auth")
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class AuthEntity {
+	@Id
+	@Column(length=19,nullable=false)
+	@SequenceGenerator(name = "SEQ_AUTH_GENERATOR",sequenceName = "SEQ_AUTH",allocationSize = 1,initialValue = 1)
+	@GeneratedValue(strategy = GenerationType.SEQUENCE,generator ="SEQ_AUTH_GENERATOR")
+	private long authId;
+	
+	@Column(length=20,nullable=false)
+	private String password;
+	
+	@Column(nullable=false)
+	private LocalDateTime connectTime;
+	
+	@PrePersist//영속화 되기전 아래 메소드 실행
+	public void setCreateDate() {
+		this.connectTime= LocalDateTime.now();		
+	}
+	
+	@PreUpdate//영속화 되기전 아래 메소드 실행
+	public void setConnectTime() {
+		this.connectTime= LocalDateTime.now();		
+	}
+	
+	@OneToOne(fetch = FetchType.LAZY, cascade=CascadeType.ALL)
+    @JoinColumn(name = "usersId", referencedColumnName = "usersId", nullable = false)
+	private UsersEntity user;
+	
+}

--- a/src/main/java/com/project/mog/repository/bios/BiosEntity.java
+++ b/src/main/java/com/project/mog/repository/bios/BiosEntity.java
@@ -4,6 +4,7 @@ import java.time.LocalDateTime;
 
 import com.project.mog.repository.users.UsersEntity;
 
+import jakarta.persistence.CascadeType;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.FetchType;
@@ -42,8 +43,8 @@ public class BiosEntity {
 	@Column(length=3,nullable=false)
 	private long weight;
 	
-	@OneToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "usersId", referencedColumnName = "usersId", nullable = false)
+	@OneToOne(fetch = FetchType.LAZY, cascade = CascadeType.ALL)
+    @JoinColumn(name = "usersId", referencedColumnName = "usersId", nullable = true)
 	private UsersEntity user;
     
 }

--- a/src/main/java/com/project/mog/repository/users/UsersEntity.java
+++ b/src/main/java/com/project/mog/repository/users/UsersEntity.java
@@ -2,6 +2,7 @@
 
 import java.time.LocalDateTime;
 
+import com.project.mog.repository.auth.AuthEntity;
 import com.project.mog.repository.bios.BiosEntity;
 
 import jakarta.persistence.CascadeType;
@@ -62,6 +63,7 @@ public class UsersEntity {
 	
 	@OneToOne(mappedBy = "user", cascade = CascadeType.ALL, fetch = FetchType.LAZY, orphanRemoval = true)
 	private BiosEntity bios;
-
+	@OneToOne(mappedBy = "user", cascade = CascadeType.ALL, fetch = FetchType.LAZY, orphanRemoval = true)
+	private AuthEntity auth;
 
 }

--- a/src/main/java/com/project/mog/service/auth/AuthDto.java
+++ b/src/main/java/com/project/mog/service/auth/AuthDto.java
@@ -1,0 +1,41 @@
+package com.project.mog.service.auth;
+
+import java.time.LocalDateTime;
+
+import com.project.mog.repository.auth.AuthEntity;
+
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class AuthDto {
+	private long authId;
+	private String password;
+	private LocalDateTime connectTime;
+	
+	public AuthEntity toEntity() {
+			return AuthEntity.builder()
+					.authId(authId)
+					.password(password)
+					.connectTime(connectTime)
+					.build();
+	}
+	
+	public static AuthDto toDto(AuthEntity aEntity) {
+		if(aEntity==null) return null;	
+		return AuthDto.builder()
+				.authId(aEntity.getAuthId())
+				.password(aEntity.getPassword())
+				.connectTime(aEntity.getConnectTime())
+				.build();
+	}
+
+}

--- a/src/main/java/com/project/mog/service/users/UsersDto.java
+++ b/src/main/java/com/project/mog/service/users/UsersDto.java
@@ -1,11 +1,15 @@
 package com.project.mog.service.users;
 
 import java.time.LocalDateTime;
+import java.util.Optional;
 
+import com.project.mog.repository.auth.AuthEntity;
 import com.project.mog.repository.bios.BiosEntity;
 import com.project.mog.repository.users.UsersEntity;
+import com.project.mog.service.auth.AuthDto;
 import com.project.mog.service.bios.BiosDto;
 
+import jakarta.annotation.Nullable;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -19,7 +23,9 @@ import lombok.Setter;
 @Builder
 public class UsersDto {
 	private long usersId;
+	@Nullable
 	private BiosDto biosDto;
+	private AuthDto authDto;
 	private String usersName;
 	private String email;
 	private String profileImg;
@@ -34,12 +40,18 @@ public class UsersDto {
 					.profileImg(profileImg)
 					.regDate(regDate)
 					.updateDate(updateDate)
-					.bios(biosDto.toEntity())
+					.bios(Optional.ofNullable(biosDto).map(BiosDto::toEntity).orElse(null))
+					.auth(authDto.toEntity())
 					.build();
 		if(biosDto!=null) {
 			BiosEntity bEntity = biosDto.toEntity();
 			bEntity.setUser(uEntity);
 			uEntity.setBios(bEntity);
+		}
+		if(authDto!=null) {
+			AuthEntity aEntity = authDto.toEntity();
+			aEntity.setUser(uEntity);
+			uEntity.setAuth(aEntity);
 		}
 		return uEntity;
 	}
@@ -54,6 +66,7 @@ public class UsersDto {
 				.regDate(uEntity.getRegDate())
 				.updateDate(uEntity.getUpdateDate())
 				.biosDto(BiosDto.toDto(uEntity.getBios()))
+				.authDto(AuthDto.toDto(uEntity.getAuth()))
 				.build();
 	}
 

--- a/src/main/java/com/project/mog/service/users/UsersService.java
+++ b/src/main/java/com/project/mog/service/users/UsersService.java
@@ -5,8 +5,8 @@ import java.util.Optional;
 import java.util.stream.Collectors;
 
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Service;
-
 
 import com.project.mog.repository.users.UsersEntity;
 import com.project.mog.repository.users.UsersRepository;
@@ -37,6 +37,14 @@ public class UsersService {
 		public Optional<UsersDto> getUser(Long usersId) {
 			
 			return usersRepository.findById(usersId).map(uEntity->UsersDto.toDto(uEntity));
+		}
+
+
+		public UsersDto deleteUser(Long usersId) {
+			UsersEntity usersEntity =usersRepository.findById(usersId).orElseThrow(()->new IllegalArgumentException(usersId+"가 존재하지 않습니다"));
+			
+			usersRepository.deleteById(usersId);
+			return UsersDto.toDto(usersEntity);
 		}
 		
 		


### PR DESCRIPTION
1. api 요청 형식 변경
- api/users/... -> api/v1/users/... 로 변경

2. AuthDto 추가
- AuthDto 추가, 회원 가입시 같이 생성되도록 구현, 필수 속성
- BiosDto는 신체정보로, 신체정보 비공개 기능 구현을 위해 nullable로 설정

3. 회원 탈퇴 구현
- 회원 탈퇴 구현
- api/v1/users/delete/{usersId}로 DELETE 요청
- 반환시 삭제된 유저의 정보 반환
- 탈퇴시 해당 유저와 관련된 정보를 모두 삭제하기 위해 Bios 및 Auth를 Cascade.ALL로 설정