### PR TITLE
feat: 회원 정보 수정 api 구현

### DIFF
--- a/src/main/java/com/project/mog/controller/users/UsersController.java
+++ b/src/main/java/com/project/mog/controller/users/UsersController.java
@@ -9,6 +9,7 @@ import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
@@ -40,6 +41,11 @@ public class UsersController {
 	public ResponseEntity<UsersDto> getUser(@PathVariable Long usersId){
 		return usersService.getUser(usersId).map(ResponseEntity::ok).orElse(ResponseEntity.notFound().build());
 				
+	}
+	@PutMapping("/update/{usersId}")
+	public ResponseEntity<UsersDto> editUser(@PathVariable Long usersId,@RequestBody UsersDto usersDto){
+		UsersDto editUsers = usersService.editUser(usersDto,usersId);
+		return ResponseEntity.status(HttpStatus.OK).body(editUsers);
 	}
 	@DeleteMapping("/delete/{usersId}")
 	public ResponseEntity<UsersDto> deleteUser(@PathVariable Long usersId){

--- a/src/main/java/com/project/mog/repository/auth/AuthRepository.java
+++ b/src/main/java/com/project/mog/repository/auth/AuthRepository.java
@@ -1,0 +1,9 @@
+package com.project.mog.repository.auth;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import com.project.mog.repository.users.UsersEntity;
+
+public interface AuthRepository extends JpaRepository<AuthEntity, Long> {
+	AuthEntity findByUser(UsersEntity user);
+}

--- a/src/main/java/com/project/mog/repository/bios/BiosRepository.java
+++ b/src/main/java/com/project/mog/repository/bios/BiosRepository.java
@@ -1,0 +1,14 @@
+package com.project.mog.repository.bios;
+
+import java.util.Optional;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import java.util.List;
+import com.project.mog.repository.users.UsersEntity;
+
+
+
+public interface BiosRepository extends JpaRepository<BiosEntity, Long> {
+	
+	BiosEntity findByUser(UsersEntity user);
+}

--- a/src/main/java/com/project/mog/repository/users/UsersRepository.java
+++ b/src/main/java/com/project/mog/repository/users/UsersRepository.java
@@ -4,8 +4,9 @@ import java.util.Optional;
 
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import com.project.mog.repository.bios.BiosEntity;
+
 public interface UsersRepository extends JpaRepository<UsersEntity, Long>{
 
 	Optional<UsersEntity> findById(Long usersId);
-
 }

--- a/src/main/java/com/project/mog/service/users/UsersService.java
+++ b/src/main/java/com/project/mog/service/users/UsersService.java
@@ -8,6 +8,10 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Service;
 
+import com.project.mog.repository.auth.AuthEntity;
+import com.project.mog.repository.auth.AuthRepository;
+import com.project.mog.repository.bios.BiosEntity;
+import com.project.mog.repository.bios.BiosRepository;
 import com.project.mog.repository.users.UsersEntity;
 import com.project.mog.repository.users.UsersRepository;
 
@@ -15,10 +19,14 @@ import com.project.mog.repository.users.UsersRepository;
 public class UsersService {
 
 		private UsersRepository usersRepository;
+		private BiosRepository biosRepository;
+		private AuthRepository authRepository;
 		
 		@Autowired
-		public UsersService(UsersRepository usersRepository) {
+		public UsersService(UsersRepository usersRepository, BiosRepository biosRepository,AuthRepository authRepository ) {
 			this.usersRepository=usersRepository;
+			this.biosRepository=biosRepository;
+			this.authRepository=authRepository;
 		}
 
 
@@ -44,6 +52,35 @@ public class UsersService {
 			UsersEntity usersEntity =usersRepository.findById(usersId).orElseThrow(()->new IllegalArgumentException(usersId+"가 존재하지 않습니다"));
 			
 			usersRepository.deleteById(usersId);
+			return UsersDto.toDto(usersEntity);
+		}
+
+
+		public UsersDto editUser(UsersDto usersDto, Long usersId) {
+			UsersEntity usersEntity =usersRepository.findById(usersId).orElseThrow(()->new IllegalArgumentException(usersId+"가 존재하지 않습니다"));
+			BiosEntity biosEntity = biosRepository.findByUser(usersEntity);
+			AuthEntity authEntity = authRepository.findByUser(usersEntity);
+			usersEntity.setUsersName(usersDto.getUsersName());
+			usersEntity.setEmail(usersDto.getEmail());
+			usersEntity.setProfileImg(usersDto.getProfileImg()!=null?usersDto.getProfileImg():null);
+			usersEntity.setUpdateDate();
+			//아래는 연관관계 업데이트
+			//biosDto 업데이트
+			if(usersDto.getBiosDto()!=null) {
+				biosEntity.setAge(usersDto.getBiosDto().getAge());
+				biosEntity.setGender(usersDto.getBiosDto().isGender());
+				biosEntity.setHeight(usersDto.getBiosDto().getHeight());
+				biosEntity.setWeight(usersDto.getBiosDto().getWeight());
+				biosEntity.setUser(usersEntity);
+			}
+			else {
+				usersEntity.setBios(null);
+			}
+			
+			
+			System.out.println("usersDto connectTime:"+usersDto.getAuthDto().getConnectTime());
+			//authDto 업데이트
+			authEntity.setPassword(usersDto.getAuthDto().getPassword());
 			return UsersDto.toDto(usersEntity);
 		}
 		


### PR DESCRIPTION
1. 회원 정보 수정 api 구현
- api/v1/users/update/{usersId}로 PUT 요청
- 반환시 수정된 유저의 정보 반환
- 회원 정보 수정시 biosDto와 authDto 전체 업데이트
- authDto의 경우 connectTime은 업데이트 되지 않음 (로그인시에만 업데이트)
- biosDto는 null값 가능 (신체정보 비공개 고려)
- 일괄 업데이트를 위해 BiosRepository, AuthRepository 추가