### PR TITLE
feat : 로그인 기능 구현

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -66,6 +66,24 @@
 			<artifactId>spring-boot-starter-test</artifactId>
 			<scope>test</scope>
 		</dependency>
+		<!-- JWT -->
+	    <dependency>
+	        <groupId>io.jsonwebtoken</groupId>
+	        <artifactId>jjwt-api</artifactId>
+	        <version>0.11.5</version>
+	    </dependency>
+	    <dependency>
+	        <groupId>io.jsonwebtoken</groupId>
+	        <artifactId>jjwt-impl</artifactId>
+	        <version>0.11.5</version>
+	        <scope>runtime</scope>
+	    </dependency>
+	    <dependency>
+	        <groupId>io.jsonwebtoken</groupId>
+	        <artifactId>jjwt-jackson</artifactId> <!-- or jjwt-gson -->
+	        <version>0.11.5</version>
+	        <scope>runtime</scope>
+	    </dependency>
 		<!--<dependency>
 			<groupId>org.springframework.security</groupId>
 			<artifactId>spring-security-test</artifactId>

--- a/src/main/java/com/project/mog/config/web/WebConfig.java
+++ b/src/main/java/com/project/mog/config/web/WebConfig.java
@@ -11,7 +11,7 @@ public class WebConfig implements WebMvcConfigurer {
 	        registry.addMapping("/api/**")
 	            .allowedOrigins("http://localhost:3000")
 	            .allowedMethods("GET", "POST", "PUT", "DELETE")
-	            .allowCredentials(true); // 이거 중요!
+	            .allowCredentials(true); 
 	    }
 }
 

--- a/src/main/java/com/project/mog/controller/login/LoginController.java
+++ b/src/main/java/com/project/mog/controller/login/LoginController.java
@@ -1,0 +1,40 @@
+package com.project.mog.controller.login;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+
+import com.project.mog.service.users.UsersDto;
+import com.project.mog.service.users.UsersService;
+import com.project.mog.util.JwtUtil;
+
+import lombok.RequiredArgsConstructor;
+
+@Controller
+@RequestMapping("/api/v1/users/")
+@RequiredArgsConstructor
+public class LoginController {
+	private final UsersService usersService;
+	private final JwtUtil jwtUtil;
+
+	@PostMapping("login")
+	public ResponseEntity<LoginResponse> login(@RequestBody LoginRequest request){
+		String email = usersService.login(request).getEmail();
+		
+		String accessToken = jwtUtil.generateAccessToken(email);
+		String refreshToken = jwtUtil.generateRefreshToken(email);
+		
+		LoginResponse loginResponse = LoginResponse.builder()
+											.email(email)
+											.accessToken(accessToken)
+											.refreshToken(refreshToken)
+											.build();
+		
+		return ResponseEntity.status(HttpStatus.OK).body(loginResponse);
+	}
+	
+	
+}

--- a/src/main/java/com/project/mog/controller/login/LoginRequest.java
+++ b/src/main/java/com/project/mog/controller/login/LoginRequest.java
@@ -1,0 +1,11 @@
+package com.project.mog.controller.login;
+
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+public class LoginRequest {
+	private String email;
+	private String password;
+}

--- a/src/main/java/com/project/mog/controller/login/LoginResponse.java
+++ b/src/main/java/com/project/mog/controller/login/LoginResponse.java
@@ -1,0 +1,18 @@
+package com.project.mog.controller.login;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Setter
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class LoginResponse {
+	private String email;
+	private String accessToken;
+	private String refreshToken;
+}

--- a/src/main/java/com/project/mog/controller/users/UsersController.java
+++ b/src/main/java/com/project/mog/controller/users/UsersController.java
@@ -53,5 +53,4 @@ public class UsersController {
 		return ResponseEntity.status(HttpStatus.OK).body(deleteUsers);
 	}
 	
-	
 }

--- a/src/main/java/com/project/mog/repository/users/UsersRepository.java
+++ b/src/main/java/com/project/mog/repository/users/UsersRepository.java
@@ -3,10 +3,15 @@ package com.project.mog.repository.users;
 import java.util.Optional;
 
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 
 import com.project.mog.repository.bios.BiosEntity;
 
 public interface UsersRepository extends JpaRepository<UsersEntity, Long>{
 
 	Optional<UsersEntity> findById(Long usersId);
+
+	@Query(nativeQuery = true,value = "SELECT USERS.* FROM USERS JOIN AUTH ON (USERS.USERSID=AUTH.USERSID) WHERE USERS.EMAIL=?1 AND AUTH.PASSWORD=?2")
+	Optional<UsersEntity> findByEmailAndPassword(String email, String password);
+
 }

--- a/src/main/java/com/project/mog/service/auth/LoginDto.java
+++ b/src/main/java/com/project/mog/service/auth/LoginDto.java
@@ -1,0 +1,20 @@
+package com.project.mog.service.auth;
+
+import java.time.LocalDateTime;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class LoginDto {
+	private String accessToken;
+	private String refreshToken;
+
+}

--- a/src/main/java/com/project/mog/service/users/UsersService.java
+++ b/src/main/java/com/project/mog/service/users/UsersService.java
@@ -8,6 +8,8 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Service;
 
+import com.project.mog.controller.login.LoginRequest;
+import com.project.mog.controller.login.LoginResponse;
 import com.project.mog.repository.auth.AuthEntity;
 import com.project.mog.repository.auth.AuthRepository;
 import com.project.mog.repository.bios.BiosEntity;
@@ -21,6 +23,7 @@ public class UsersService {
 		private UsersRepository usersRepository;
 		private BiosRepository biosRepository;
 		private AuthRepository authRepository;
+		
 		
 		@Autowired
 		public UsersService(UsersRepository usersRepository, BiosRepository biosRepository,AuthRepository authRepository ) {
@@ -64,7 +67,10 @@ public class UsersService {
 			usersEntity.setEmail(usersDto.getEmail());
 			usersEntity.setProfileImg(usersDto.getProfileImg()!=null?usersDto.getProfileImg():null);
 			usersEntity.setUpdateDate();
+			
+			
 			//아래는 연관관계 업데이트
+			
 			//biosDto 업데이트
 			if(usersDto.getBiosDto()!=null) {
 				biosEntity.setAge(usersDto.getBiosDto().getAge());
@@ -78,11 +84,19 @@ public class UsersService {
 			}
 			
 			
-			System.out.println("usersDto connectTime:"+usersDto.getAuthDto().getConnectTime());
 			//authDto 업데이트
 			authEntity.setPassword(usersDto.getAuthDto().getPassword());
 			return UsersDto.toDto(usersEntity);
 		}
+
+		
+		public UsersDto login(LoginRequest request) {
+			UsersEntity usersEntity = usersRepository.findByEmailAndPassword(request.getEmail(),request.getPassword()).orElseThrow(()-> new IllegalArgumentException("올바르지 않은 아이디/비밀번호입니다"));
+			
+			return UsersDto.toDto(usersEntity);
+			
+		}
+		
 		
 		
 }

--- a/src/main/java/com/project/mog/util/JwtUtil.java
+++ b/src/main/java/com/project/mog/util/JwtUtil.java
@@ -1,0 +1,75 @@
+package com.project.mog.util;
+
+import java.util.Base64;
+import java.util.Date;
+
+import javax.crypto.SecretKey;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+import io.jsonwebtoken.JwtException;
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.SignatureAlgorithm;
+import io.jsonwebtoken.security.Keys;
+import jakarta.annotation.PostConstruct;
+
+
+@Component
+public class JwtUtil {
+	
+	@Value("${jwttoken.secret-key}")
+	private String secretKey;
+	
+	private SecretKey key; 
+	
+	@PostConstruct
+	public void initKey() {
+		byte[] decoded = Base64.getDecoder().decode(secretKey);
+		this.key = Keys.hmacShaKeyFor(decoded);
+	}
+	
+	
+	private final long ACCESS_TOKEN_EXPIRE = 1000*60*15;
+	private final long REFRESH_TOKEN_EXPIRE = 1000L*60*60*24*24;
+	
+	public String generateAccessToken(String email) {
+		return generateToken(email,ACCESS_TOKEN_EXPIRE);
+	}
+	public String generateRefreshToken(String email) {
+		return generateToken(email,REFRESH_TOKEN_EXPIRE);
+	}
+	
+	private String generateToken(String email, long exp) {
+		Date now = new Date();
+		
+		return Jwts.builder()
+				.setSubject(email)
+				.setIssuedAt(now)
+				.setExpiration(new Date(now.getTime()+exp))
+				.signWith(key,SignatureAlgorithm.HS256)
+				.compact();
+	}
+	
+	public String extractUserEmail(String token) {
+		return Jwts.parserBuilder()
+				.setSigningKey(key)
+				.build()
+				.parseClaimsJws(token)
+				.getBody()
+				.getSubject();
+				
+	}
+	
+	public boolean isTokenValid(String token) {
+		try {
+			Jwts.parserBuilder().setSigningKey(key).build().parseClaimsJws(token);
+			return true;
+		}catch(JwtException e) {
+			return false;
+		}
+		
+	}
+	
+	
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -37,3 +37,6 @@ spring:
       properties:
         hibernate:
           format_sql: true
+
+jwttoken:
+  secret-key: Nf/vIRqt0/bKThqJ6tOy2M9tqJX+rJxGG9HrZgsBrT4=


### PR DESCRIPTION
1. 로그인 기능 구현
- api/v1/users/login으로 POST 요청
- RequestBody : {email, password}
- 로그인 성공시 {email, accessToken, refreshToken} 반환
- refreshToken으로 로그인 상태 갱신은 추후 구현 예정
- 사용자 정보 수정 및 사용자 탈퇴 api에 해당 accessToken 기준으로 Authorization header로 검증 예정