### PR TITLE
feat : Spring Security 설정 및 인가/인증 설정 구현

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -34,12 +34,12 @@
 			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-starter-data-jpa</artifactId>
 		</dependency>
-		<!--
+		
 		<dependency>
 			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-starter-security</artifactId>
 		</dependency>
-		-->
+		
 		<dependency>
 			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-starter-web</artifactId>

--- a/src/main/java/com/project/mog/config/security/SecurityConfig.java
+++ b/src/main/java/com/project/mog/config/security/SecurityConfig.java
@@ -1,0 +1,102 @@
+package com.project.mog.config.security;
+
+import com.project.mog.filter.JwtAuthenticationFilter;
+import com.project.mog.security.UsersDetailService;
+import com.project.mog.security.jwt.JwtUtil;
+
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+
+import java.io.IOException;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.access.AccessDeniedException;
+import org.springframework.security.authentication.AuthenticationManager;
+import org.springframework.security.config.annotation.authentication.builders.AuthenticationManagerBuilder;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.http.SessionCreationPolicy;
+import org.springframework.security.core.userdetails.UsernameNotFoundException;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.access.AccessDeniedHandler;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
+
+@Configuration
+@EnableWebSecurity
+public class SecurityConfig {
+
+	private final JwtUtil jwtUtil;
+	private final UsersDetailService usersDetailService;
+	
+	public SecurityConfig(JwtUtil jwtUtil, UsersDetailService usersDetailsService) {
+		this.jwtUtil = jwtUtil;
+		this.usersDetailService= usersDetailsService;
+	}
+    
+	
+	@Bean
+	protected SecurityFilterChain filterChain(HttpSecurity http) throws Exception{
+		System.out.println("called?");
+		SecurityFilterChain result = http.csrf(csrf -> csrf.disable())
+				.sessionManagement(session -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
+				.authorizeHttpRequests(auth -> auth.requestMatchers(
+						"/api/v1/users/list",
+						"/api/v1/users/login",
+						"/api/v1/users/signup",
+						"/api/v1/users/*",
+						"/error"
+						
+						).permitAll()
+				.anyRequest().authenticated())
+				.addFilterBefore(jwtAuthenticationFilter(), UsernamePasswordAuthenticationFilter.class)
+				.exceptionHandling(	
+							ex-> ex.authenticationEntryPoint((req,res,ex2)->{
+								res.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
+								res.setContentType("text/plain;charset=UTF-8");
+								if(ex2 instanceof UsernameNotFoundException) {
+									res.getWriter().write("[401 Unauthorized] 인증되지 않음 : 테스트테스트");
+								}
+								else {
+									res.getWriter().write("[401 Unauthorized] 인증되지 않음 : 인증이 필요합니다");
+									
+								}
+								
+								
+							})
+							.accessDeniedHandler((req,res,ex2)->{
+								res.setStatus(HttpServletResponse.SC_FORBIDDEN);
+								res.setContentType("text/plain;charset=UTF-8");
+								res.getWriter().write("[403 Forbidden] 접근이 거부되었습니다 : 권한이 없습니다");
+							})
+							
+			        )
+				.build();
+		
+		System.out.println("RESULT:"+result);
+		return result;
+	}
+	
+	@Bean
+	public AuthenticationManager authenticationManager(HttpSecurity http) throws Exception {
+		AuthenticationManagerBuilder authBuilder =http.getSharedObject(AuthenticationManagerBuilder.class);
+		
+		authBuilder.userDetailsService(usersDetailService)
+					.passwordEncoder(getPasswordEncoder());
+		return authBuilder.build();
+	}
+	
+	@Bean
+    protected JwtAuthenticationFilter jwtAuthenticationFilter() {
+        return new JwtAuthenticationFilter(jwtUtil, usersDetailService);
+    }
+	
+
+    @Bean
+    protected BCryptPasswordEncoder getPasswordEncoder() {
+        return new BCryptPasswordEncoder();
+    }
+
+}

--- a/src/main/java/com/project/mog/controller/login/LoginController.java
+++ b/src/main/java/com/project/mog/controller/login/LoginController.java
@@ -7,9 +7,9 @@ import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 
+import com.project.mog.security.jwt.JwtUtil;
 import com.project.mog.service.users.UsersDto;
 import com.project.mog.service.users.UsersService;
-import com.project.mog.util.JwtUtil;
 
 import lombok.RequiredArgsConstructor;
 

--- a/src/main/java/com/project/mog/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/project/mog/exception/GlobalExceptionHandler.java
@@ -1,0 +1,43 @@
+package com.project.mog.exception;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.AccessDeniedException;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+import org.springframework.web.client.HttpClientErrorException.Unauthorized;
+
+@RestControllerAdvice
+public class GlobalExceptionHandler {
+
+	
+	@ExceptionHandler(IllegalArgumentException.class)
+	public ResponseEntity<String> handleIllegalArgument(IllegalArgumentException ex){
+		return ResponseEntity
+				.status(HttpStatus.BAD_REQUEST)
+				.body("[400 Bad Request] 잘못된 요청 : "+ex.getMessage());
+	}
+	
+	@ExceptionHandler(Unauthorized.class)
+	public ResponseEntity<String> handleUnauthorized(Unauthorized ex){
+		return ResponseEntity
+				.status(HttpStatus.UNAUTHORIZED)
+				.body("[401 Unauthorized] 인증되지 않음 : "+ex.getMessage());
+	}
+	
+	@ExceptionHandler(AccessDeniedException.class)
+	public ResponseEntity<String> handleIllegalArgument(AccessDeniedException ex){
+		return ResponseEntity
+				.status(HttpStatus.FORBIDDEN)
+				.body("[403 Forbidden] 접근이 거부되었습니다 : "+ex.getMessage());
+	}
+	
+	
+	@ExceptionHandler(Exception.class)
+	public ResponseEntity<String> handleGeneralException(Exception ex){
+		return ResponseEntity
+				.status(HttpStatus.INTERNAL_SERVER_ERROR)
+				.body("[500 Internal Server Error] 서버 오류 : " + ex.getMessage());
+	}
+
+}

--- a/src/main/java/com/project/mog/filter/JwtAuthenticationFilter.java
+++ b/src/main/java/com/project/mog/filter/JwtAuthenticationFilter.java
@@ -1,0 +1,68 @@
+package com.project.mog.filter;
+
+import java.io.IOException;
+
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.core.userdetails.UsernameNotFoundException;
+import org.springframework.security.web.authentication.WebAuthenticationDetailsSource;
+import org.springframework.stereotype.Component;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import com.project.mog.security.UsersDetailService;
+import com.project.mog.security.UsersDetails;
+import com.project.mog.security.jwt.JwtUtil;
+
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+
+@Component
+@RequiredArgsConstructor
+public class JwtAuthenticationFilter extends OncePerRequestFilter {
+
+	private final JwtUtil jwtUtil;
+	private final UsersDetailService usersDetailService;
+	
+	@Override
+	protected void doFilterInternal(HttpServletRequest request, 
+									HttpServletResponse response, 
+									FilterChain filterChain)
+									throws ServletException, IOException {
+		String header = request.getHeader("Authorization");
+		System.out.println("JwtAuthenticationFilter doFilterInternal 실행됨: " + request.getRequestURI());
+		if(header!=null && header.startsWith("Bearer ")) {
+			String token = header.substring(7);
+			System.out.println("토큰: " + token);
+			String email = jwtUtil.extractUserEmail(token);
+			
+			if(email!=null&&SecurityContextHolder.getContext().getAuthentication()==null) {
+				try {
+					UserDetails usersDetails = usersDetailService.loadUserByUsername(email);
+				
+				
+					if(jwtUtil.isTokenValid(token,usersDetails)) {
+						UsernamePasswordAuthenticationToken authentication =
+								new UsernamePasswordAuthenticationToken(email, null, usersDetails.getAuthorities());
+						System.out.println("인증 객체 설정됨: " + authentication);
+						authentication.setDetails(new WebAuthenticationDetailsSource().buildDetails(request));
+						
+						SecurityContextHolder.getContext().setAuthentication(authentication);
+					}
+				}
+				catch(UsernameNotFoundException ex) {
+					response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
+			        response.setContentType("text/plain;charset=UTF-8");
+				}
+			}
+			
+		}
+		filterChain.doFilter(request, response);
+		
+	}
+
+	
+}

--- a/src/main/java/com/project/mog/repository/users/UsersRepository.java
+++ b/src/main/java/com/project/mog/repository/users/UsersRepository.java
@@ -14,4 +14,6 @@ public interface UsersRepository extends JpaRepository<UsersEntity, Long>{
 	@Query(nativeQuery = true,value = "SELECT USERS.* FROM USERS JOIN AUTH ON (USERS.USERSID=AUTH.USERSID) WHERE USERS.EMAIL=?1 AND AUTH.PASSWORD=?2")
 	Optional<UsersEntity> findByEmailAndPassword(String email, String password);
 
+	@Query(nativeQuery = true,value="SELECT * FROM USERS WHERE USERS.EMAIL=?1")
+	UsersEntity findByEmail(String email);
 }

--- a/src/main/java/com/project/mog/security/UsersDetailService.java
+++ b/src/main/java/com/project/mog/security/UsersDetailService.java
@@ -1,0 +1,30 @@
+package com.project.mog.security;
+
+import org.springframework.security.authentication.BadCredentialsException;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.security.core.userdetails.UsernameNotFoundException;
+import org.springframework.stereotype.Service;
+
+import com.project.mog.repository.users.UsersEntity;
+import com.project.mog.repository.users.UsersRepository;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+public class UsersDetailService implements UserDetailsService{
+
+	private final UsersRepository usersRepository;
+
+	@Override
+	public UserDetails loadUserByUsername(String email) throws UsernameNotFoundException{
+			UsersEntity users = usersRepository.findByEmail(email);
+			if(users==null) throw new UsernameNotFoundException("계정을 찾을 수 없습니다");
+			return new UsersDetails(users);
+		
+	}
+	
+	
+	
+}

--- a/src/main/java/com/project/mog/security/UsersDetails.java
+++ b/src/main/java/com/project/mog/security/UsersDetails.java
@@ -1,0 +1,66 @@
+package com.project.mog.security;
+
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.userdetails.UserDetails;
+
+import com.project.mog.repository.users.UsersEntity;
+
+public class UsersDetails implements UserDetails {
+	private UsersEntity usersEntity;
+	
+	public UsersDetails(UsersEntity usersEntity) {
+		this.usersEntity = usersEntity;
+	}
+	
+	@Override
+	public Collection<? extends GrantedAuthority> getAuthorities() {
+		
+		return List.of(new SimpleGrantedAuthority("ROLE_USER"));
+	}
+
+	@Override
+	public String getPassword() {
+		// 비밀번호 정보 제공
+		return usersEntity.getAuth().getPassword();
+	}
+
+	@Override
+	public String getUsername() {
+		// ID 정보 제공
+		return usersEntity.getEmail();
+	}
+
+	@Override
+	public boolean isAccountNonExpired() {
+		//계정 만료 여부
+		//사용 안할시 항상 true 반환 처리
+		return true;
+	}
+
+	@Override
+	public boolean isAccountNonLocked() {
+		// 계정 비활성화 여부
+		// 사용 안할시 항상 true 반환 처리
+		return true;
+	}
+
+	@Override
+	public boolean isCredentialsNonExpired() {
+		// 계정 인증 정보 항상 저장 여부
+		// true 처리시 모든 인증정보를 만료시키지 않으므로 false처리
+		return false;
+	}
+
+	@Override
+	public boolean isEnabled() {
+		// 계정 활성화 여부
+		// 사용 안할시 항상 true 처리
+		return true;
+	}
+	
+}

--- a/src/main/java/com/project/mog/security/jwt/JwtUtil.java
+++ b/src/main/java/com/project/mog/security/jwt/JwtUtil.java
@@ -1,0 +1,72 @@
+package com.project.mog.security.jwt;
+
+import java.util.Base64;
+import java.util.Date;
+
+import javax.crypto.SecretKey;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.stereotype.Component;
+
+import io.jsonwebtoken.JwtException;
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.SignatureAlgorithm;
+import io.jsonwebtoken.security.Keys;
+import jakarta.annotation.PostConstruct;
+
+
+@Component
+public class JwtUtil {
+	
+	@Value("${jwttoken.secret-key}")
+	private String secretKey;
+	
+	private SecretKey key; 
+	
+	@PostConstruct
+	public void initKey() {
+		byte[] decoded = Base64.getDecoder().decode(secretKey);
+		this.key = Keys.hmacShaKeyFor(decoded);
+	}
+	
+	
+	private final long ACCESS_TOKEN_EXPIRE = 1000*60*60*15;
+	private final long REFRESH_TOKEN_EXPIRE = 1000L*60*60*24*24;
+	
+	public String generateAccessToken(String email) {
+		return generateToken(email,ACCESS_TOKEN_EXPIRE);
+	}
+	public String generateRefreshToken(String email) {
+		return generateToken(email,REFRESH_TOKEN_EXPIRE);
+	}
+	
+	private String generateToken(String email, long exp) {
+		Date now = new Date();
+		
+		return Jwts.builder()
+				.setSubject(email)
+				.setIssuedAt(now)
+				.setExpiration(new Date(now.getTime()+exp))
+				.signWith(key,SignatureAlgorithm.HS256)
+				.compact();
+	}
+	
+	public String extractUserEmail(String token) {
+		return Jwts.parserBuilder()
+				.setSigningKey(key)
+				.build()
+				.parseClaimsJws(token)
+				.getBody()
+				.getSubject();
+				
+	}
+	
+	public boolean isTokenValid(String token, UserDetails userDetails) {
+		final String email = extractUserEmail(token);
+		return email.equals(userDetails.getUsername());
+		
+	}
+	
+	
+}

--- a/src/main/java/com/project/mog/service/users/UsersService.java
+++ b/src/main/java/com/project/mog/service/users/UsersService.java
@@ -1,11 +1,13 @@
 package com.project.mog.service.users;
 
+
 import java.util.List;
 import java.util.Optional;
 import java.util.stream.Collectors;
 
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.AccessDeniedException;
 import org.springframework.stereotype.Service;
 
 import com.project.mog.controller.login.LoginRequest;
@@ -39,6 +41,8 @@ public class UsersService {
 
 
 		public UsersDto createUser(UsersDto usersDto) {
+			UsersEntity isDuplicated = usersRepository.findByEmail(usersDto.getEmail());
+			if(isDuplicated!=null) throw new IllegalArgumentException("중복된 아이디입니다");
 			UsersEntity uEntity = usersRepository.save(usersDto.toEntity());
 			
 			return UsersDto.toDto(uEntity);
@@ -46,25 +50,34 @@ public class UsersService {
 
 
 		public Optional<UsersDto> getUser(Long usersId) {
-			
 			return usersRepository.findById(usersId).map(uEntity->UsersDto.toDto(uEntity));
 		}
 
 
-		public UsersDto deleteUser(Long usersId) {
-			UsersEntity usersEntity =usersRepository.findById(usersId).orElseThrow(()->new IllegalArgumentException(usersId+"가 존재하지 않습니다"));
+		public UsersDto deleteUser(Long usersId, String authEmail) {
+			UsersEntity currentUser = usersRepository.findByEmail(authEmail);
+			UsersEntity targetUser = usersRepository.findById(usersId).orElseThrow(()->new RuntimeException("삭제할 사용자를 찾을 수 없습니다"));
+			
+			//권한을 가진 유저의 수정 요청인지 확인
+			if(currentUser.getUsersId()!=targetUser.getUsersId()) throw new AccessDeniedException("자기 자신만 삭제 가능합니다");
 			
 			usersRepository.deleteById(usersId);
-			return UsersDto.toDto(usersEntity);
+			return UsersDto.toDto(targetUser);
 		}
 
 
-		public UsersDto editUser(UsersDto usersDto, Long usersId) {
+		public UsersDto editUser(UsersDto usersDto, Long usersId, String authEmail) {
+			UsersEntity currentUser = usersRepository.findByEmail(authEmail);
+			UsersEntity targetUser = usersRepository.findById(usersId).orElseThrow(()->new RuntimeException("수정할 사용자를 찾을 수 없습니다"));
+			
+			//권한을 가진 유저의 수정 요청인지 확인
+			if(currentUser.getUsersId()!=targetUser.getUsersId()) throw new AccessDeniedException("자기 자신만 수정 가능합니다");
+			
+			
 			UsersEntity usersEntity =usersRepository.findById(usersId).orElseThrow(()->new IllegalArgumentException(usersId+"가 존재하지 않습니다"));
 			BiosEntity biosEntity = biosRepository.findByUser(usersEntity);
 			AuthEntity authEntity = authRepository.findByUser(usersEntity);
 			usersEntity.setUsersName(usersDto.getUsersName());
-			usersEntity.setEmail(usersDto.getEmail());
 			usersEntity.setProfileImg(usersDto.getProfileImg()!=null?usersDto.getProfileImg():null);
 			usersEntity.setUpdateDate();
 			
@@ -86,6 +99,7 @@ public class UsersService {
 			
 			//authDto 업데이트
 			authEntity.setPassword(usersDto.getAuthDto().getPassword());
+			
 			return UsersDto.toDto(usersEntity);
 		}
 

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -30,7 +30,7 @@ spring:
   #Spring Data JPA 설정
     jpa:
       hibernate:
-        ddl-auto: update
+        ddl-auto: create
         naming:
           physical-strategy: org.hibernate.boot.model.naming.PhysicalNamingStrategyStandardImpl
       show-sql: true


### PR DESCRIPTION
1. Spring Security 설정 및 인가/인증 설정 구현
- Spring Security 설정
- HTTP 및 그외 에러시 에러 메시지 일부 구현
- 사용자 정보 수정 및 탈퇴시 accessToken 사용하도록 변경
- 로그인후 받은 accessToken을 Header에 Authentication : Bearer {accessToken} 넣으면 api 요청 가능함
- 사용자 정보 추가 및 수정시 중복 이메일 사용 불가하도록 설정
- 사용자 정보 수정시 이메일은 수정 불가능하도록 업데이트 사항에서 제외