### PR TITLE
feat : routinemain api 일부 구현, 사용자인증 AOP 설정

### DIFF
--- a/src/main/java/com/project/mog/annotation/UserAuthorizationCheck.java
+++ b/src/main/java/com/project/mog/annotation/UserAuthorizationCheck.java
@@ -1,0 +1,12 @@
+package com.project.mog.annotation;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target(ElementType.METHOD)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface UserAuthorizationCheck {
+	
+}

--- a/src/main/java/com/project/mog/aop/UserAuthorizationAspect.java
+++ b/src/main/java/com/project/mog/aop/UserAuthorizationAspect.java
@@ -1,0 +1,47 @@
+package com.project.mog.aop;
+
+import org.aspectj.lang.ProceedingJoinPoint;
+import org.aspectj.lang.annotation.Around;
+import org.aspectj.lang.annotation.Aspect;
+import org.springframework.security.access.AccessDeniedException;
+import org.springframework.stereotype.Component;
+
+import com.project.mog.repository.users.UsersEntity;
+import com.project.mog.repository.users.UsersRepository;
+
+import lombok.RequiredArgsConstructor;
+
+@Aspect
+@Component
+@RequiredArgsConstructor
+public class UserAuthorizationAspect {
+	
+	private final UsersRepository usersRepository;
+	
+	@Around("@annotation(com.project.mog.annotation.UserAuthorizationCheck)")
+	public Object checkUserAuthorization(ProceedingJoinPoint joinPoint) throws Throwable {
+		
+		Object[] args = joinPoint.getArgs();
+		
+		Long userId = null;
+		String authEmail = null;
+		
+		for(Object arg : args) {
+			if(arg instanceof Long) userId = (Long) arg;
+			if(arg instanceof String && ((String) arg).contains("@")) authEmail = (String) arg;
+		}
+		System.out.println("ANNOTATION동작"+userId+" , "+ authEmail);
+		if(userId == null|| authEmail==null) {
+			throw new IllegalArgumentException("유저 정보가 충분하지 않습니다");
+		}
+		UsersEntity targetUser = usersRepository.findById(userId).orElseThrow(()->new RuntimeException("수정할 사용자를 찾을 수 없습니다"));
+		UsersEntity currentUser = usersRepository.findByEmail(authEmail);
+		
+		if(currentUser.getUsersId()!=userId) {
+			throw new AccessDeniedException("유저 권한이 없습니다");
+		}
+		
+		return joinPoint.proceed();
+	}
+
+}

--- a/src/main/java/com/project/mog/config/web/WebConfig.java
+++ b/src/main/java/com/project/mog/config/web/WebConfig.java
@@ -1,9 +1,11 @@
 package com.project.mog.config.web;
 
 import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.EnableAspectJAutoProxy;
 import org.springframework.web.servlet.config.annotation.CorsRegistry;
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
 
+@EnableAspectJAutoProxy
 @Configuration
 public class WebConfig implements WebMvcConfigurer {
 	    @Override

--- a/src/main/java/com/project/mog/controller/routine/RoutineController.java
+++ b/src/main/java/com/project/mog/controller/routine/RoutineController.java
@@ -1,0 +1,55 @@
+package com.project.mog.controller.routine;
+
+import java.util.List;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestHeader;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.project.mog.security.jwt.JwtUtil;
+import com.project.mog.service.routine.RoutineDto;
+import com.project.mog.service.routine.RoutineService;
+import com.project.mog.service.users.UsersDto;
+
+import lombok.RequiredArgsConstructor;
+
+@RestController
+@RequestMapping("/api/v1/routine/")
+@RequiredArgsConstructor
+public class RoutineController {
+	
+	private final JwtUtil jwtUtil;
+	private final RoutineService routineService;
+	
+	@GetMapping("list")
+	public ResponseEntity<List<RoutineDto>> getAllRoutines(@RequestHeader("Authorization") String authHeader){
+		String token = authHeader.replace("Bearer ", "");
+		String authEmail = jwtUtil.extractUserEmail(token);
+		List<RoutineDto> routines = routineService.getAllRoutines(authEmail);
+		return ResponseEntity.ok(routines);
+	}
+	
+	@GetMapping("details/{setId}")
+	public ResponseEntity<RoutineDto> getRoutineDetail(@RequestHeader("Authorization") String authHeader, @PathVariable long setId){
+		String token = authHeader.replace("Bearer ", "");
+		String authEmail = jwtUtil.extractUserEmail(token);
+		RoutineDto routine = routineService.getRoutine(authEmail, setId);
+		System.out.println(routine);
+		return ResponseEntity.ok(routine);
+	}
+	
+	
+	@PostMapping("create")
+	public ResponseEntity<RoutineDto> createRoutine(@RequestHeader("Authorization") String authHeader, @RequestBody RoutineDto routineDto){
+		String token = authHeader.replace("Bearer ", "");
+		String authEmail = jwtUtil.extractUserEmail(token);
+		RoutineDto routine = routineService.createRoutine(authEmail,routineDto);
+		return ResponseEntity.status(HttpStatus.CREATED).body(routine);
+	}
+}

--- a/src/main/java/com/project/mog/repository/routine/RoutineEntity.java
+++ b/src/main/java/com/project/mog/repository/routine/RoutineEntity.java
@@ -1,0 +1,45 @@
+package com.project.mog.repository.routine;
+
+import java.time.LocalDateTime;
+
+import com.project.mog.repository.auth.AuthEntity;
+import com.project.mog.repository.bios.BiosEntity;
+import com.project.mog.repository.users.UsersEntity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.SequenceGenerator;
+import jakarta.persistence.Table;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Entity
+@Table(name="routinemain")
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class RoutineEntity {
+	@Id
+	@Column(length=19,nullable=false)
+	@SequenceGenerator(name = "SEQ_ROUTINE_GENERATOR",sequenceName = "SEQ_ROUTINE",allocationSize = 1,initialValue = 1)
+	@GeneratedValue(strategy = GenerationType.SEQUENCE,generator ="SEQ_ROUTINE_GENERATOR" )	
+	private long setId;
+	
+	@Column(length=200)
+	private String routineName;
+	
+	@ManyToOne(fetch = FetchType.LAZY)
+	@JoinColumn(name = "usersId", referencedColumnName = "usersId", nullable = true)
+	private UsersEntity user;
+}

--- a/src/main/java/com/project/mog/repository/routine/RoutineRepository.java
+++ b/src/main/java/com/project/mog/repository/routine/RoutineRepository.java
@@ -1,0 +1,17 @@
+package com.project.mog.repository.routine;
+import java.util.List;
+import java.util.Optional;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+
+import com.project.mog.service.routine.RoutineDto;
+
+public interface RoutineRepository extends JpaRepository<RoutineEntity, Long>{
+	
+	@Query(nativeQuery=true,value="SELECT * FROM routinemain WHERE usersid =?1")
+	public List<RoutineEntity> findByUsersId(Long usersId);
+
+	@Query(nativeQuery=true,value="SELECT * FROM routinemain WHERE usersid =?1 AND setid=?2")
+	public Optional<RoutineEntity> findByUsersIdAndSetId(Long usersId, Long setId);
+}

--- a/src/main/java/com/project/mog/service/routine/RoutineDto.java
+++ b/src/main/java/com/project/mog/service/routine/RoutineDto.java
@@ -1,0 +1,33 @@
+package com.project.mog.service.routine;
+
+import com.project.mog.repository.routine.RoutineEntity;
+import com.project.mog.service.bios.BiosDto;
+import com.project.mog.service.users.UsersDto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class RoutineDto {
+	private long setId;
+	private String routineName;
+	private long usersId;
+	
+	
+	
+	public static RoutineDto toDto(RoutineEntity rEntity) {
+		if(rEntity==null) return null;
+		return RoutineDto.builder()
+				.setId(rEntity.getSetId())
+				.routineName(rEntity.getRoutineName())
+				.usersId(rEntity.getUser().getUsersId())
+				.build();
+	}
+}

--- a/src/main/java/com/project/mog/service/routine/RoutineService.java
+++ b/src/main/java/com/project/mog/service/routine/RoutineService.java
@@ -1,0 +1,50 @@
+package com.project.mog.service.routine;
+
+import java.nio.file.AccessDeniedException;
+import java.util.List;
+import java.util.stream.Collectors;
+
+import org.springframework.stereotype.Service;
+
+import com.project.mog.annotation.UserAuthorizationCheck;
+import com.project.mog.repository.routine.RoutineEntity;
+import com.project.mog.repository.routine.RoutineRepository;
+import com.project.mog.repository.users.UsersEntity;
+import com.project.mog.repository.users.UsersRepository;
+import com.project.mog.service.users.UsersDto;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+public class RoutineService {
+	
+	private final UsersRepository usersRepository;
+	private final RoutineRepository routineRepository;
+	
+	public RoutineEntity toEntity(UsersEntity uEntity, RoutineDto routineDto) {
+		RoutineEntity rEntity = RoutineEntity.builder()
+								.routineName(routineDto.getRoutineName())
+								.user(uEntity)
+								.build();
+		return rEntity;
+	}
+
+	public List<RoutineDto> getAllRoutines(String authEmail) {
+		UsersEntity currentUser = usersRepository.findByEmail(authEmail);
+		return routineRepository.findByUsersId(currentUser.getUsersId()).stream().map(RoutineDto::toDto).collect(Collectors.toList());
+	}
+	
+	public RoutineDto getRoutine(String authEmail, Long setId) {
+		UsersEntity currentUser = usersRepository.findByEmail(authEmail);
+		RoutineEntity routineEntity = routineRepository.findByUsersIdAndSetId(currentUser.getUsersId(),setId).orElseThrow(()->new IllegalArgumentException("해당 루틴 정보가 없습니다"));
+		return RoutineDto.toDto(routineEntity); 
+	}
+
+	public RoutineDto createRoutine(String authEmail,RoutineDto routineDto) {
+		UsersEntity uEntity = usersRepository.findByEmail(authEmail);
+		RoutineEntity routineEntity = routineRepository.save(toEntity(uEntity,routineDto));
+		return RoutineDto.toDto(routineEntity);
+	}
+
+}

--- a/src/main/java/com/project/mog/service/users/UsersService.java
+++ b/src/main/java/com/project/mog/service/users/UsersService.java
@@ -10,6 +10,7 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.AccessDeniedException;
 import org.springframework.stereotype.Service;
 
+import com.project.mog.annotation.UserAuthorizationCheck;
 import com.project.mog.controller.login.LoginRequest;
 import com.project.mog.controller.login.LoginResponse;
 import com.project.mog.repository.auth.AuthEntity;
@@ -53,7 +54,7 @@ public class UsersService {
 			return usersRepository.findById(usersId).map(uEntity->UsersDto.toDto(uEntity));
 		}
 
-
+		@UserAuthorizationCheck
 		public UsersDto deleteUser(Long usersId, String authEmail) {
 			UsersEntity currentUser = usersRepository.findByEmail(authEmail);
 			UsersEntity targetUser = usersRepository.findById(usersId).orElseThrow(()->new RuntimeException("삭제할 사용자를 찾을 수 없습니다"));
@@ -65,14 +66,14 @@ public class UsersService {
 			return UsersDto.toDto(targetUser);
 		}
 
-
+		@UserAuthorizationCheck
 		public UsersDto editUser(UsersDto usersDto, Long usersId, String authEmail) {
-			UsersEntity currentUser = usersRepository.findByEmail(authEmail);
-			UsersEntity targetUser = usersRepository.findById(usersId).orElseThrow(()->new RuntimeException("수정할 사용자를 찾을 수 없습니다"));
-			
-			//권한을 가진 유저의 수정 요청인지 확인
-			if(currentUser.getUsersId()!=targetUser.getUsersId()) throw new AccessDeniedException("자기 자신만 수정 가능합니다");
-			
+//			UsersEntity currentUser = usersRepository.findByEmail(authEmail);
+//			UsersEntity targetUser = usersRepository.findById(usersId).orElseThrow(()->new RuntimeException("수정할 사용자를 찾을 수 없습니다"));
+//			
+//			//권한을 가진 유저의 수정 요청인지 확인
+//			if(currentUser.getUsersId()!=targetUser.getUsersId()) throw new AccessDeniedException("자기 자신만 수정 가능합니다");
+//			
 			
 			UsersEntity usersEntity =usersRepository.findById(usersId).orElseThrow(()->new IllegalArgumentException(usersId+"가 존재하지 않습니다"));
 			BiosEntity biosEntity = biosRepository.findByUser(usersEntity);
@@ -103,7 +104,6 @@ public class UsersService {
 			return UsersDto.toDto(usersEntity);
 		}
 
-		
 		public UsersDto login(LoginRequest request) {
 			UsersEntity usersEntity = usersRepository.findByEmailAndPassword(request.getEmail(),request.getPassword()).orElseThrow(()-> new IllegalArgumentException("올바르지 않은 아이디/비밀번호입니다"));
 			


### PR DESCRIPTION
1. routinemain api 일부 구현
- RoutineEntity, RoutineDto 구현
- 루틴 전체 조회
  - api/v1/routine/list로 GET 요청
  - Authorization 필요
  - RequestBody : 없음
  - 요청 성공시 사용자가 소유한 전체 루틴 반환
  - 사용자 정보는 usersId만 반환
- 루틴 단일 조회
  -  api/v1/routine/details/{setId}로 GET 요청
  - Authorization 필요
  - RequestBody : 없음
  - 요청 성공시 요청한 단일 루틴에 대한 정보 반환 (상세 루틴 정보 반환 예정)
  - 사용자 정보는 usersId만 반환
- 루틴 생성
  - api/v1/routine/create로 요청
  - Authorization 필요
  - RequestBody : routineName
  - 요청 성공시 body dto 값에 따라 루틴 생성

2. 사용자인증 AOP 설정
- authEmail과 usersId로 사용자인증 및 검증이 필요할시를 위해 AOP Annotation 추가
- @UserAuthorizationCheck 추가함으로써 검증
- 현재 UsersService의 사용자 정보 수정 및 탈퇴에 적용됨