### PR TITLE
feat: Swagger API 명세서 구현, 사용자 Api 명세 추가 외

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -72,6 +72,17 @@
 	        <artifactId>jjwt-api</artifactId>
 	        <version>0.11.5</version>
 	    </dependency>
+	    <!-- Swagger -->
+	   <dependency>
+	    	<groupId>org.springdoc</groupId>
+		    <artifactId>springdoc-openapi-starter-webmvc-ui</artifactId>
+		    <version>2.8.0</version>
+		</dependency>
+		<dependency>
+	        <groupId>io.swagger.core.v3</groupId>
+	        <artifactId>swagger-annotations</artifactId>
+	        <version>2.2.20</version>
+	    </dependency>
 	    <dependency>
 	        <groupId>io.jsonwebtoken</groupId>
 	        <artifactId>jjwt-impl</artifactId>

--- a/src/main/java/com/project/mog/MogBackendApplication.java
+++ b/src/main/java/com/project/mog/MogBackendApplication.java
@@ -3,6 +3,7 @@ package com.project.mog;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 
+
 @SpringBootApplication
 public class MogBackendApplication {
 

--- a/src/main/java/com/project/mog/config/security/SecurityConfig.java
+++ b/src/main/java/com/project/mog/config/security/SecurityConfig.java
@@ -47,6 +47,9 @@ public class SecurityConfig {
 						"/api/v1/users/login",
 						"/api/v1/users/signup",
 						"/api/v1/users/*",
+						"/swagger-ui/*",
+						"/swagger-resources/**",
+						"/v3/api-docs/**",
 						"/error"
 						
 						).permitAll()

--- a/src/main/java/com/project/mog/config/swagger/SwaggerConfig.java
+++ b/src/main/java/com/project/mog/config/swagger/SwaggerConfig.java
@@ -1,0 +1,38 @@
+package com.project.mog.config.swagger;
+
+import java.lang.annotation.Annotation;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.servlet.config.annotation.EnableWebMvc;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+import io.swagger.v3.oas.models.OpenAPI;
+import io.swagger.v3.oas.models.info.Info;
+import io.swagger.v3.oas.models.security.SecurityRequirement;
+import io.swagger.v3.oas.models.security.SecurityScheme;
+
+
+
+@Configuration
+public class SwaggerConfig implements WebMvcConfigurer {
+	@Bean
+	protected OpenAPI openApi() {//Swagger 문서를 설정하는 OpenAPI 객체 Bean으로 등록
+		// Security Scheme 정의
+				SecurityScheme securityScheme = new SecurityScheme()
+													.type(SecurityScheme.Type.HTTP)
+													.scheme("bearer")
+													.bearerFormat("JWT")
+													.in(SecurityScheme.In.HEADER)
+													.name("Authorization");
+				// Security Requirement 정의
+				SecurityRequirement securityRequirement = new SecurityRequirement().addList("BearerAuth");
+		return new OpenAPI()
+				.info(new Info().title("MOG(My Own Gym)")
+				.description("MOG API 명세서")
+				.version("v1.0.0")
+				).addSecurityItem(securityRequirement)
+				.schemaRequirement("BearerAuth", securityScheme);
+	}
+				
+}

--- a/src/main/java/com/project/mog/controller/login/LoginRequest.java
+++ b/src/main/java/com/project/mog/controller/login/LoginRequest.java
@@ -1,11 +1,14 @@
 package com.project.mog.controller.login;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Getter;
 import lombok.Setter;
 
 @Getter
 @Setter
 public class LoginRequest {
+	@Schema(description = "email",example="test@test.com")
 	private String email;
+	@Schema(description = "password",example="testuser1")
 	private String password;
 }

--- a/src/main/java/com/project/mog/controller/login/LoginResponse.java
+++ b/src/main/java/com/project/mog/controller/login/LoginResponse.java
@@ -1,5 +1,6 @@
 package com.project.mog.controller.login;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -12,6 +13,9 @@ import lombok.Setter;
 @AllArgsConstructor
 @Builder
 public class LoginResponse {
+	@Schema(description = "usersId",example="1")
+	private Long usersId;
+	@Schema(description = "email",example="test@test.com")
 	private String email;
 	private String accessToken;
 	private String refreshToken;

--- a/src/main/java/com/project/mog/controller/users/UsersController.java
+++ b/src/main/java/com/project/mog/controller/users/UsersController.java
@@ -16,18 +16,25 @@ import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
+import com.project.mog.controller.login.LoginRequest;
+import com.project.mog.controller.login.LoginResponse;
+import com.project.mog.docs.UsersControllerDocs;
 import com.project.mog.repository.users.UsersEntity;
 import com.project.mog.security.jwt.JwtUtil;
 import com.project.mog.service.users.UsersDto;
 import com.project.mog.service.users.UsersService;
 
+
+import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
+
+
 
 @RestController
 @RequestMapping("/api/v1/users/")
 @RequiredArgsConstructor
-public class UsersController {
+public class UsersController implements UsersControllerDocs{
 	private final JwtUtil jwtUtil;
 	private final UsersService usersService;
 	
@@ -62,6 +69,27 @@ public class UsersController {
 		String authEmail = jwtUtil.extractUserEmail(token);
 		UsersDto deleteUsers = usersService.deleteUser(usersId,authEmail);
 		return ResponseEntity.status(HttpStatus.OK).body(deleteUsers);
+	}
+	
+	
+	@PostMapping("login")
+	public ResponseEntity<LoginResponse> login(@RequestBody LoginRequest request){
+		UsersDto usersDto = usersService.login(request);
+		
+		long usersId = usersDto.getUsersId();
+		String email = usersDto.getEmail();
+		String accessToken = jwtUtil.generateAccessToken(email);
+		String refreshToken = jwtUtil.generateRefreshToken(email);
+		
+		
+		LoginResponse loginResponse = LoginResponse.builder()
+											.usersId(usersId)
+											.email(email)
+											.accessToken(accessToken)
+											.refreshToken(refreshToken)
+											.build();
+		
+		return ResponseEntity.status(HttpStatus.OK).body(loginResponse);
 	}
 	
 }

--- a/src/main/java/com/project/mog/docs/UsersControllerDocs.java
+++ b/src/main/java/com/project/mog/docs/UsersControllerDocs.java
@@ -1,0 +1,98 @@
+package com.project.mog.docs;
+
+import java.util.List;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestHeader;
+
+import com.project.mog.controller.login.LoginRequest;
+import com.project.mog.controller.login.LoginResponse;
+import com.project.mog.service.users.UsersDto;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
+import io.swagger.v3.oas.annotations.security.OAuthScope;
+import io.swagger.v3.oas.annotations.tags.Tag;
+
+@Tag(name="사용자 API", description="사용자 계정 관련 API 입니다")
+public interface UsersControllerDocs {
+	
+	@Operation(summary="전체 회원 조회",description="전체 회원 정보 조회 API")
+	public ResponseEntity<List<UsersDto>> getAllUsers();
+	
+	@Operation(summary="단일 회원 조회 ", description="단일 회원 정보 조회 API")
+	@Parameter(description="usersId", name="usersId", required=true)
+	public ResponseEntity<UsersDto> getUser(@PathVariable Long usersId);
+	
+	@Operation(summary="회원 가입", description="회원 가입 API")
+	public ResponseEntity<UsersDto> createUser(
+			@io.swagger.v3.oas.annotations.parameters.RequestBody(
+					content = @Content(
+							schema = @Schema(implementation = UsersDto.class),
+							examples= @ExampleObject(value="{\r\n"
+									+ "    \"usersName\":\"테스트유저\",\r\n"
+									+ "    \"email\":\"test@test.com\",\r\n"
+									+ "    \"profileImg\":\"profileImg.png\",\r\n"
+									+ "    \"biosDto\":{\r\n"
+									+ "        \"gender\":0,\r\n"
+									+ "        \"age\":40,\r\n"
+									+ "        \"height\":180,\r\n"
+									+ "        \"weight\":90\r\n"
+									+ "    },\r\n"
+									+ "    \"authDto\":{\r\n"
+									+ "        \"password\":\"testuser\"\r\n"
+									+ "    }\r\n"
+									+ "\r\n"
+									+ "\r\n"
+									+ "}")
+							)
+			)
+			@RequestBody UsersDto usersDto);
+
+	@Operation(summary="회원 정보 수정", description="회원 정보 수정 API")
+	@Parameter(name="Authorization", hidden=true)
+	@Parameter(description="usersId", name="usersId", required=true)
+	public ResponseEntity<UsersDto> editUser(@Parameter(hidden=true) @RequestHeader("Authorization") String authHeader, @PathVariable Long usersId, @io.swagger.v3.oas.annotations.parameters.RequestBody(
+			content = @Content(
+					schema = @Schema(implementation = UsersDto.class),
+					examples= @ExampleObject(value="{\r\n"
+							+ "    \"usersName\":\"테스트유저4\",\r\n"
+							+ "    \"email\":\"test3@test.com\",\r\n"
+							+ "    \"profileImg\":\"profileImg.png\",\r\n"
+							+ "    \"biosDto\":{\r\n"
+							+ "        \"gender\":0,\r\n"
+							+ "        \"age\":50,\r\n"
+							+ "        \"height\":180,\r\n"
+							+ "        \"weight\":90\r\n"
+							+ "    },\r\n"
+							+ "    \"authDto\":{\r\n"
+							+ "        \"password\":\"testuser3\"\r\n"
+							+ "    }\r\n"
+							+ "\r\n"
+							+ "\r\n"
+							+ "}")
+					)
+	)@RequestBody UsersDto usersDto);
+	
+	@Operation(summary="회원 탈퇴", description="회원 탈퇴 API")
+	@Parameter(description="usersId", name="usersId", required=true)
+	public ResponseEntity<UsersDto> deleteUser(@Parameter(hidden=true) @RequestHeader("Authorization") String authHeader, @PathVariable Long usersId);
+	
+	@Operation(summary="로그인", description="로그인 API")
+	public ResponseEntity<LoginResponse> login(@io.swagger.v3.oas.annotations.parameters.RequestBody(
+			content = @Content(
+					schema = @Schema(implementation = LoginRequest.class),
+					examples= @ExampleObject(value="{\r\n"
+							+ "    \"email\":\"test@test.com\",\r\n"
+							+ "    \"password\":\"testuser\"\r\n"
+							+ "}")
+					)
+	)@RequestBody LoginRequest request);
+		
+		
+}

--- a/src/main/java/com/project/mog/repository/users/UsersEntity.java
+++ b/src/main/java/com/project/mog/repository/users/UsersEntity.java
@@ -31,7 +31,6 @@ import lombok.Setter;
 @AllArgsConstructor
 @Builder
 public class UsersEntity {
-	
 	@Id
 	@Column(length=19,nullable=false)
 	@SequenceGenerator(name = "SEQ_USERS_GENERATOR",sequenceName = "SEQ_USERS",allocationSize = 1,initialValue = 1)

--- a/src/main/java/com/project/mog/service/auth/AuthDto.java
+++ b/src/main/java/com/project/mog/service/auth/AuthDto.java
@@ -4,7 +4,7 @@ import java.time.LocalDateTime;
 
 import com.project.mog.repository.auth.AuthEntity;
 
-
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -17,7 +17,9 @@ import lombok.Setter;
 @AllArgsConstructor
 @Builder
 public class AuthDto {
+	@Schema(description = "authId",example="1")
 	private long authId;
+	@Schema(description = "password",example="testuser1")
 	private String password;
 	private LocalDateTime connectTime;
 	

--- a/src/main/java/com/project/mog/service/bios/BiosDto.java
+++ b/src/main/java/com/project/mog/service/bios/BiosDto.java
@@ -6,6 +6,7 @@ import com.project.mog.repository.bios.BiosEntity;
 import com.project.mog.repository.users.UsersEntity;
 import com.project.mog.service.users.UsersDto;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.persistence.Column;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -19,10 +20,15 @@ import lombok.Setter;
 @AllArgsConstructor
 @Builder
 public class BiosDto {
+	@Schema(description = "bioId",example="1")
 	private long bioId;
+	@Schema(description = "age",example="25")
 	private long age;
+	@Schema(description = "gender",example="false")
 	private boolean gender;
+	@Schema(description = "height",example="170")
 	private long height;
+	@Schema(description = "weight",example="70")
 	private long weight;
 	
 	public BiosEntity toEntity() {

--- a/src/main/java/com/project/mog/service/users/UsersDto.java
+++ b/src/main/java/com/project/mog/service/users/UsersDto.java
@@ -9,6 +9,7 @@ import com.project.mog.repository.users.UsersEntity;
 import com.project.mog.service.auth.AuthDto;
 import com.project.mog.service.bios.BiosDto;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.annotation.Nullable;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -22,12 +23,16 @@ import lombok.Setter;
 @AllArgsConstructor
 @Builder
 public class UsersDto {
+	@Schema(description = "usersId",example="1")
 	private long usersId;
 	@Nullable
 	private BiosDto biosDto;
 	private AuthDto authDto;
+	@Schema(description = "usersName",example="테스트유저")
 	private String usersName;
+	@Schema(description = "email",example="test@test.com")
 	private String email;
+	@Schema(description = "profileImg",example="profileImg.png")
 	private String profileImg;
 	private LocalDateTime regDate;
 	private LocalDateTime updateDate;


### PR DESCRIPTION
1. Swagger API 명세서 구현
- Swagger Api 명세서 구현
- Swagger 관련 설정 및 Authorization을 통한 api 사용 테스트 완료
2. 사용자 Api 명세 추가
- 사용자 Api 명세사항 추가
3. 로그인 Api 일부 수정
- 프론트 요청에 따라 로그인시 usersId 반환하도록 수정