### PR TITLE
feat : 루틴 결과 등록 api 구현

### DIFF
--- a/src/main/java/com/project/mog/config/security/SecurityConfig.java
+++ b/src/main/java/com/project/mog/config/security/SecurityConfig.java
@@ -53,6 +53,7 @@ public class SecurityConfig {
 						"/api/v1/users/list",
 						"/api/v1/users/login",
 						"/api/v1/users/signup",
+						"/api/v1/routine/**",
 						"/api/v1/users/*",
 						"/swagger-ui/*",
 						"/swagger-resources/**",

--- a/src/main/java/com/project/mog/controller/routine/RoutineController.java
+++ b/src/main/java/com/project/mog/controller/routine/RoutineController.java
@@ -4,6 +4,7 @@ import java.util.List;
 
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -14,7 +15,9 @@ import org.springframework.web.bind.annotation.RestController;
 
 import com.project.mog.security.jwt.JwtUtil;
 import com.project.mog.service.routine.RoutineDto;
+import com.project.mog.service.routine.RoutineEndTotalDto;
 import com.project.mog.service.routine.RoutineService;
+import com.project.mog.service.routine.SaveRoutineDto;
 import com.project.mog.service.users.UsersDto;
 
 import lombok.RequiredArgsConstructor;
@@ -27,6 +30,7 @@ public class RoutineController {
 	private final JwtUtil jwtUtil;
 	private final RoutineService routineService;
 	
+	//루틴 관련 api
 	@GetMapping("list")
 	public ResponseEntity<List<RoutineDto>> getAllRoutines(@RequestHeader("Authorization") String authHeader){
 		String token = authHeader.replace("Bearer ", "");
@@ -35,7 +39,7 @@ public class RoutineController {
 		return ResponseEntity.ok(routines);
 	}
 	
-	@GetMapping("details/{setId}")
+	@GetMapping("{setId}")
 	public ResponseEntity<RoutineDto> getRoutineDetail(@RequestHeader("Authorization") String authHeader, @PathVariable long setId){
 		String token = authHeader.replace("Bearer ", "");
 		String authEmail = jwtUtil.extractUserEmail(token);
@@ -52,4 +56,26 @@ public class RoutineController {
 		RoutineDto routine = routineService.createRoutine(authEmail,routineDto);
 		return ResponseEntity.status(HttpStatus.CREATED).body(routine);
 	}
+	
+	@PostMapping("{setId}/save")
+	public ResponseEntity<SaveRoutineDto> createSaveRoutine(@RequestBody SaveRoutineDto saveRoutineDto, @PathVariable Long setId){
+		SaveRoutineDto saveRoutine = routineService.createSaveRoutine(saveRoutineDto,setId);
+		return ResponseEntity.status(HttpStatus.CREATED).body(saveRoutine);
+	}
+	
+	@DeleteMapping("save/{srId}")
+	public ResponseEntity<SaveRoutineDto> deleteSaveRoutine(@PathVariable Long srId){
+	
+		SaveRoutineDto saveRoutine = routineService.deleteSaveRoutine(srId);
+		return ResponseEntity.status(HttpStatus.OK).body(saveRoutine);
+	}
+	
+	
+	//루틴 결과 관련 api
+	@PostMapping("{setId}/result")
+	public ResponseEntity<RoutineEndTotalDto> createRoutineEndTotal(@RequestBody RoutineEndTotalDto routineEndTotalDto,@PathVariable Long setId){
+		RoutineEndTotalDto routineEndTotal = routineService.createRoutineEndTotal(routineEndTotalDto,setId);
+		return ResponseEntity.status(HttpStatus.CREATED).body(routineEndTotal);
+	}
+	
 }

--- a/src/main/java/com/project/mog/controller/users/UsersController.java
+++ b/src/main/java/com/project/mog/controller/users/UsersController.java
@@ -2,6 +2,7 @@ package com.project.mog.controller.users;
 
 import java.util.List;
 
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.HttpStatusCode;
 import org.springframework.http.ResponseEntity;
@@ -14,6 +15,7 @@ import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 import com.project.mog.controller.login.LoginRequest;
@@ -26,6 +28,7 @@ import com.project.mog.service.users.UsersInfoDto;
 import com.project.mog.service.users.UsersService;
 
 import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.servlet.http.HttpSession;
 import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
 
@@ -37,6 +40,7 @@ import lombok.RequiredArgsConstructor;
 public class UsersController implements UsersControllerDocs{
 	private final JwtUtil jwtUtil;
 	private final UsersService usersService;
+	
 	
 	@GetMapping("list")
 	public ResponseEntity<List<UsersInfoDto>> getAllUsers(){
@@ -91,5 +95,6 @@ public class UsersController implements UsersControllerDocs{
 		
 		return ResponseEntity.status(HttpStatus.OK).body(loginResponse);
 	}
+	
 	
 }

--- a/src/main/java/com/project/mog/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/project/mog/exception/GlobalExceptionHandler.java
@@ -33,11 +33,6 @@ public class GlobalExceptionHandler {
 	}
 	
 	
-	@ExceptionHandler(Exception.class)
-	public ResponseEntity<String> handleGeneralException(Exception ex){
-		return ResponseEntity
-				.status(HttpStatus.INTERNAL_SERVER_ERROR)
-				.body("[500 Internal Server Error] 서버 오류 : " + ex.getMessage());
-	}
+	
 
 }

--- a/src/main/java/com/project/mog/repository/auth/AuthEntity.java
+++ b/src/main/java/com/project/mog/repository/auth/AuthEntity.java
@@ -38,7 +38,7 @@ public class AuthEntity {
 	@GeneratedValue(strategy = GenerationType.SEQUENCE,generator ="SEQ_AUTH_GENERATOR")
 	private long authId;
 	
-	@Column(length=20,nullable=false)
+	@Column(length=100,nullable=false)
 	private String password;
 	
 	@Column(nullable=false)

--- a/src/main/java/com/project/mog/repository/routine/RoutineEndDetailEntity.java
+++ b/src/main/java/com/project/mog/repository/routine/RoutineEndDetailEntity.java
@@ -1,0 +1,52 @@
+package com.project.mog.repository.routine;
+
+import java.time.LocalDateTime;
+
+import jakarta.persistence.CascadeType;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.SequenceGenerator;
+import jakarta.persistence.Table;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Entity
+@Table(name="routineenddetail")
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class RoutineEndDetailEntity {
+	@Id
+	@Column(length=19,nullable=false)
+	@SequenceGenerator(name = "SEQ_RED_GENERATOR",sequenceName = "SEQ_RED",allocationSize = 1,initialValue = 1)
+	@GeneratedValue(strategy = GenerationType.SEQUENCE,generator ="SEQ_RED_GENERATOR" )	
+	private long redId;
+	
+	@Column(length=19)
+	private String srName;
+	
+	@Column(length=19)
+	private long setNumber;
+	
+	@Column(length=19)
+	private long reps;
+	
+	@Column(length=19)
+	private long weight;
+	
+	@ManyToOne(fetch = FetchType.LAZY)
+	@JoinColumn(name = "retId", nullable = false)
+	private RoutineEndTotalEntity routineEndTotal;
+	
+}

--- a/src/main/java/com/project/mog/repository/routine/RoutineEndDetailRepository.java
+++ b/src/main/java/com/project/mog/repository/routine/RoutineEndDetailRepository.java
@@ -1,0 +1,7 @@
+package com.project.mog.repository.routine;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface RoutineEndDetailRepository extends JpaRepository<RoutineEndDetailEntity, Long> {
+
+}

--- a/src/main/java/com/project/mog/repository/routine/RoutineEndTotalEntity.java
+++ b/src/main/java/com/project/mog/repository/routine/RoutineEndTotalEntity.java
@@ -3,8 +3,6 @@ package com.project.mog.repository.routine;
 import java.time.LocalDateTime;
 import java.util.List;
 
-import com.project.mog.repository.auth.AuthEntity;
-import com.project.mog.repository.bios.BiosEntity;
 import com.project.mog.repository.users.UsersEntity;
 
 import jakarta.persistence.CascadeType;
@@ -27,26 +25,30 @@ import lombok.NoArgsConstructor;
 import lombok.Setter;
 
 @Entity
-@Table(name="routinemain")
+@Table(name="routineendtotal")
 @Getter
 @Setter
 @NoArgsConstructor
 @AllArgsConstructor
 @Builder
-public class RoutineEntity {
+public class RoutineEndTotalEntity {
 	@Id
 	@Column(length=19,nullable=false)
-	@SequenceGenerator(name = "SEQ_ROUTINE_GENERATOR",sequenceName = "SEQ_ROUTINE",allocationSize = 1,initialValue = 1)
-	@GeneratedValue(strategy = GenerationType.SEQUENCE,generator ="SEQ_ROUTINE_GENERATOR" )	
-	private long setId;
+	@SequenceGenerator(name = "SEQ_RET_GENERATOR",sequenceName = "SEQ_RET",allocationSize = 1,initialValue = 1)
+	@GeneratedValue(strategy = GenerationType.SEQUENCE,generator ="SEQ_RET_GENERATOR" )	
+	private long retId;
 	
-	@Column(length=200)
-	private String routineName;
+	private LocalDateTime tStart;
+	private LocalDateTime tEnd;
 	
 	@ManyToOne(fetch = FetchType.LAZY)
-	@JoinColumn(name = "usersId", referencedColumnName = "usersId", nullable = false)
-	private UsersEntity user;
+	@JoinColumn(name = "setId", referencedColumnName = "setId", nullable = true)
+	private RoutineEntity routine;
 	
-	@OneToMany(mappedBy = "routine",fetch = FetchType.LAZY)
-	private List<SaveRoutineEntity> saveRoutine;
+	@OneToMany(mappedBy = "routineEndTotal", cascade = CascadeType.ALL, orphanRemoval = true)
+	private List<RoutineEndDetailEntity> routineEndDetail;
+	
+	@OneToOne(fetch = FetchType.LAZY)
+	@JoinColumn(name="rrId",referencedColumnName="rrId",nullable=false)
+	private RoutineResultEntity routineResult;
 }

--- a/src/main/java/com/project/mog/repository/routine/RoutineEndTotalRepository.java
+++ b/src/main/java/com/project/mog/repository/routine/RoutineEndTotalRepository.java
@@ -1,0 +1,7 @@
+package com.project.mog.repository.routine;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface RoutineEndTotalRepository extends JpaRepository<RoutineEndTotalEntity, Long> {
+
+}

--- a/src/main/java/com/project/mog/repository/routine/RoutineResultEntity.java
+++ b/src/main/java/com/project/mog/repository/routine/RoutineResultEntity.java
@@ -1,0 +1,43 @@
+package com.project.mog.repository.routine;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.SequenceGenerator;
+import jakarta.persistence.Table;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Entity
+@Table(name="routineresult")
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class RoutineResultEntity {
+	@Id
+	@Column(length=19,nullable=false)
+	@SequenceGenerator(name = "SEQ_RR_GENERATOR",sequenceName = "SEQ_RR",allocationSize = 1,initialValue = 1)
+	@GeneratedValue(strategy = GenerationType.SEQUENCE,generator ="SEQ_RR_GENERATOR" )	
+	private long rrId;
+	@Column(length = 19)
+	private long muscle;
+	@Column(length = 19)
+	private long kcal;
+	@Column(length = 19)
+	private long reSet;
+	@Column(length = 19)
+	private long setNum;
+	@Column(length = 19)
+	private long volum;
+	@Column(length = 19)
+	private long rouTime;
+	@Column(length = 19)
+	private long exVolum;
+}

--- a/src/main/java/com/project/mog/repository/routine/RoutineResultRepository.java
+++ b/src/main/java/com/project/mog/repository/routine/RoutineResultRepository.java
@@ -1,0 +1,7 @@
+package com.project.mog.repository.routine;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface RoutineResultRepository extends JpaRepository<RoutineResultEntity, Long> {
+
+}

--- a/src/main/java/com/project/mog/repository/routine/SaveRoutineEntity.java
+++ b/src/main/java/com/project/mog/repository/routine/SaveRoutineEntity.java
@@ -1,0 +1,49 @@
+package com.project.mog.repository.routine;
+
+import com.project.mog.repository.users.UsersEntity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.SequenceGenerator;
+import jakarta.persistence.Table;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Entity
+@Table(name="saveroutine")
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class SaveRoutineEntity {
+	@Id
+	@Column(length=19,nullable=false)
+	@SequenceGenerator(name = "SEQ_SR_GENERATOR",sequenceName = "SEQ_SR",allocationSize = 1,initialValue = 1)
+	@GeneratedValue(strategy = GenerationType.SEQUENCE,generator ="SEQ_SR_GENERATOR" )	
+	private long srId;
+	@Column(length=19)
+	private long exId;
+	@Column(length=200)
+	private String srName;
+	@Column(length=19)
+	private long setNumber;
+	@Column(length=19)
+	private long reps;
+	@Column(length=3)
+	private long weight;
+	
+	@ManyToOne(fetch = FetchType.LAZY)
+	@JoinColumn(name = "setId", referencedColumnName = "setId", nullable = true)
+	private RoutineEntity routine;
+	
+}

--- a/src/main/java/com/project/mog/repository/routine/SaveRoutineRepository.java
+++ b/src/main/java/com/project/mog/repository/routine/SaveRoutineRepository.java
@@ -1,0 +1,12 @@
+package com.project.mog.repository.routine;
+import java.util.List;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+
+public interface SaveRoutineRepository extends JpaRepository<SaveRoutineEntity, Long> {
+
+	@Query(nativeQuery = true,value = "SELECT * FROM SAVEROUTINE WHERE SETID=?1")
+	List<SaveRoutineEntity> findAllBySetId(Long setId);
+
+}

--- a/src/main/java/com/project/mog/service/routine/RoutineDto.java
+++ b/src/main/java/com/project/mog/service/routine/RoutineDto.java
@@ -1,6 +1,10 @@
 package com.project.mog.service.routine;
 
+import java.util.List;
+import java.util.stream.Collectors;
+
 import com.project.mog.repository.routine.RoutineEntity;
+import com.project.mog.repository.routine.SaveRoutineEntity;
 import com.project.mog.service.bios.BiosDto;
 import com.project.mog.service.users.UsersDto;
 
@@ -19,15 +23,25 @@ public class RoutineDto {
 	private long setId;
 	private String routineName;
 	private long usersId;
-	
+	private List<SaveRoutineDto> saveRoutineDto;
 	
 	
 	public static RoutineDto toDto(RoutineEntity rEntity) {
 		if(rEntity==null) return null;
+		List<SaveRoutineEntity> srEntity = rEntity.getSaveRoutine();
+		List<SaveRoutineDto> srDto;
+		if(srEntity==null) {
+			srDto = List.of();
+		}
+		else {
+			srDto = srEntity.stream().map(SaveRoutineDto::toDto).collect(Collectors.toList());
+			
+		}
 		return RoutineDto.builder()
 				.setId(rEntity.getSetId())
 				.routineName(rEntity.getRoutineName())
 				.usersId(rEntity.getUser().getUsersId())
+				.saveRoutineDto(srDto)
 				.build();
 	}
 }

--- a/src/main/java/com/project/mog/service/routine/RoutineEndDetailDto.java
+++ b/src/main/java/com/project/mog/service/routine/RoutineEndDetailDto.java
@@ -1,0 +1,45 @@
+package com.project.mog.service.routine;
+
+import com.project.mog.repository.routine.RoutineEndDetailEntity;
+import com.project.mog.repository.routine.RoutineEndTotalEntity;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class RoutineEndDetailDto {
+	private long redId;
+	private String srName;
+	private long setNumber;
+	private long reps;
+	private long weight;
+	private RoutineEndTotalEntity routineEndTotalEntity;
+	
+	public RoutineEndDetailEntity toEntity(RoutineEndTotalEntity retEntity) {
+		return RoutineEndDetailEntity.builder()
+									.srName(srName)
+									.setNumber(setNumber)
+									.reps(reps)
+									.weight(weight)
+									.routineEndTotal(retEntity)
+									.build();
+	}
+	
+	public static RoutineEndDetailDto toDto(RoutineEndDetailEntity redEntity) {
+		if(redEntity==null) return null;
+		return RoutineEndDetailDto.builder()
+								.redId(redEntity.getRedId())
+								.srName(redEntity.getSrName())
+								.setNumber(redEntity.getSetNumber())
+								.reps(redEntity.getReps())
+								.weight(redEntity.getWeight())
+								.build();
+	}
+}

--- a/src/main/java/com/project/mog/service/routine/RoutineEndTotalDto.java
+++ b/src/main/java/com/project/mog/service/routine/RoutineEndTotalDto.java
@@ -1,0 +1,56 @@
+package com.project.mog.service.routine;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.stream.Collectors;
+
+import com.fasterxml.jackson.annotation.JsonFormat;
+import com.project.mog.repository.routine.RoutineEndDetailEntity;
+import com.project.mog.repository.routine.RoutineEndTotalEntity;
+import com.project.mog.repository.routine.RoutineEntity;
+import com.project.mog.repository.routine.RoutineResultEntity;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class RoutineEndTotalDto {
+	private long retId;
+	@JsonFormat(pattern = "yyyy-MM-dd'T'HH:mm:ss.SSSSSSS")
+	private LocalDateTime tStart;
+	@JsonFormat(pattern = "yyyy-MM-dd'T'HH:mm:ss.SSSSSSS")
+	private LocalDateTime tEnd;
+	private List<RoutineEndDetailDto> routineEndDetails;
+	private RoutineResultDto routineResult;
+	
+	
+	
+	public static RoutineEndTotalDto toDto(RoutineEndTotalEntity retEntity) {
+		if(retEntity==null) return null;
+		List<RoutineEndDetailEntity> redEntity = retEntity.getRoutineEndDetail();
+		RoutineResultEntity rrEntity = retEntity.getRoutineResult();
+		List<RoutineEndDetailDto> redDto;
+		if(redEntity==null) {
+			redDto = List.of();
+		}
+		else {
+			redDto = redEntity.stream().map(RoutineEndDetailDto::toDto).collect(Collectors.toList());
+		}
+		
+		return RoutineEndTotalDto.builder()
+								.retId(retEntity.getRetId())
+								.tStart(retEntity.getTStart())
+								.tEnd(retEntity.getTEnd())
+								.routineEndDetails(redDto)
+								.routineResult(RoutineResultDto.toDto(rrEntity))
+								.build();
+	
+	}
+}

--- a/src/main/java/com/project/mog/service/routine/RoutineResultDto.java
+++ b/src/main/java/com/project/mog/service/routine/RoutineResultDto.java
@@ -1,0 +1,51 @@
+package com.project.mog.service.routine;
+
+import com.project.mog.repository.routine.RoutineResultEntity;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class RoutineResultDto {
+	private long rrId;
+	private long muscle;
+	private long kcal;
+	private long reSet;
+	private long setNum;
+	private long volum;
+	private long rouTime;
+	private long exVolum;
+	
+	public RoutineResultEntity toEntity() {
+		System.out.println(rrId);
+		return RoutineResultEntity.builder()
+								.muscle(muscle)
+								.kcal(kcal)
+								.reSet(reSet)
+								.setNum(setNum)
+								.volum(exVolum)
+								.rouTime(rouTime)
+								.exVolum(exVolum)
+								.build();
+	}
+	
+	public static RoutineResultDto toDto(RoutineResultEntity rrEntity) {
+		if(rrEntity==null) return null;
+		return RoutineResultDto.builder()
+								.rrId(rrEntity.getRrId())
+								.muscle(rrEntity.getMuscle())
+								.kcal(rrEntity.getKcal())
+								.reSet(rrEntity.getReSet())
+								.volum(rrEntity.getVolum())
+								.rouTime(rrEntity.getRouTime())
+								.exVolum(rrEntity.getExVolum())
+								.build();
+	}
+}

--- a/src/main/java/com/project/mog/service/routine/RoutineService.java
+++ b/src/main/java/com/project/mog/service/routine/RoutineService.java
@@ -2,17 +2,27 @@ package com.project.mog.service.routine;
 
 import java.nio.file.AccessDeniedException;
 import java.util.List;
+import java.util.Optional;
 import java.util.stream.Collectors;
 
 import org.springframework.stereotype.Service;
 
 import com.project.mog.annotation.UserAuthorizationCheck;
+import com.project.mog.repository.routine.RoutineEndDetailEntity;
+import com.project.mog.repository.routine.RoutineEndDetailRepository;
+import com.project.mog.repository.routine.RoutineEndTotalEntity;
+import com.project.mog.repository.routine.RoutineEndTotalRepository;
 import com.project.mog.repository.routine.RoutineEntity;
 import com.project.mog.repository.routine.RoutineRepository;
+import com.project.mog.repository.routine.RoutineResultEntity;
+import com.project.mog.repository.routine.RoutineResultRepository;
+import com.project.mog.repository.routine.SaveRoutineEntity;
+import com.project.mog.repository.routine.SaveRoutineRepository;
 import com.project.mog.repository.users.UsersEntity;
 import com.project.mog.repository.users.UsersRepository;
 import com.project.mog.service.users.UsersDto;
 
+import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
 
 @Service
@@ -21,6 +31,10 @@ public class RoutineService {
 	
 	private final UsersRepository usersRepository;
 	private final RoutineRepository routineRepository;
+	private final SaveRoutineRepository saveRoutineRepository;
+	private final RoutineEndTotalRepository routineEndTotalRepository;
+	private final RoutineEndDetailRepository routineEndDetailRepository;
+	private final RoutineResultRepository routineResultRepository;
 	
 	public RoutineEntity toEntity(UsersEntity uEntity, RoutineDto routineDto) {
 		RoutineEntity rEntity = RoutineEntity.builder()
@@ -29,6 +43,20 @@ public class RoutineService {
 								.build();
 		return rEntity;
 	}
+	public RoutineEndTotalEntity toEntity(RoutineEndTotalDto retDto, Long setId) {
+		RoutineEntity rEntity = routineRepository.findById(setId).orElseThrow(()->new IllegalArgumentException("루틴을 찾을 수 없습니다"));
+		RoutineEndTotalEntity retEntity = RoutineEndTotalEntity.builder()
+				.tStart(retDto.getTStart())
+				.tEnd(retDto.getTEnd())
+				.routineResult(retDto.getRoutineResult().toEntity())
+				.build();
+		List<RoutineEndDetailEntity> redEntity = retDto.getRoutineEndDetails().stream()
+													.map(detailDto -> detailDto.toEntity(retEntity))
+													.collect(Collectors.toList());
+		retEntity.setRoutineEndDetail(redEntity);
+		return retEntity;
+	}
+	
 
 	public List<RoutineDto> getAllRoutines(String authEmail) {
 		UsersEntity currentUser = usersRepository.findByEmail(authEmail);
@@ -38,6 +66,8 @@ public class RoutineService {
 	public RoutineDto getRoutine(String authEmail, Long setId) {
 		UsersEntity currentUser = usersRepository.findByEmail(authEmail);
 		RoutineEntity routineEntity = routineRepository.findByUsersIdAndSetId(currentUser.getUsersId(),setId).orElseThrow(()->new IllegalArgumentException("해당 루틴 정보가 없습니다"));
+		List<SaveRoutineEntity> saveRoutineEntity = saveRoutineRepository.findAllBySetId(setId);
+		routineEntity.setSaveRoutine(saveRoutineEntity);
 		return RoutineDto.toDto(routineEntity); 
 	}
 
@@ -45,6 +75,35 @@ public class RoutineService {
 		UsersEntity uEntity = usersRepository.findByEmail(authEmail);
 		RoutineEntity routineEntity = routineRepository.save(toEntity(uEntity,routineDto));
 		return RoutineDto.toDto(routineEntity);
+	}
+	
+	public SaveRoutineDto createSaveRoutine(SaveRoutineDto saveRoutineDto, Long setId) {
+		RoutineEntity routineEntity = routineRepository.findById(setId).orElseThrow(()->new IllegalArgumentException("루틴을 찾을 수 없습니다"));
+		SaveRoutineEntity saveRoutineEntity = saveRoutineDto.toEntity(routineEntity);
+		saveRoutineRepository.save(saveRoutineEntity);
+		return SaveRoutineDto.toDto(saveRoutineEntity);
+	}
+
+	public SaveRoutineDto deleteSaveRoutine(Long srId) {
+		SaveRoutineEntity saveRoutineEntity = saveRoutineRepository.findById(srId).orElseThrow(()->new IllegalArgumentException("삭제할 루틴 상세를 찾을 수 없습니다"));
+		saveRoutineRepository.deleteById(srId);
+		return SaveRoutineDto.toDto(saveRoutineEntity);
+	}
+
+	public RoutineEndTotalDto createRoutineEndTotal(RoutineEndTotalDto retDto, Long setId) {
+		RoutineEntity routineEntity = routineRepository.findById(setId).orElseThrow(()->new IllegalArgumentException("루틴을 찾을 수 없습니다"));
+		RoutineResultEntity rrEntity = retDto.getRoutineResult().toEntity();
+		routineResultRepository.save(rrEntity);
+		RoutineEndTotalEntity retEntity = RoutineEndTotalEntity.builder()
+											.tStart(retDto.getTStart())
+											.tEnd(retDto.getTEnd())
+											.routine(routineEntity)
+											.routineResult(rrEntity)
+											.build();
+		List<RoutineEndDetailEntity> redEntity = retDto.getRoutineEndDetails().stream().map(red->{red.setRoutineEndTotalEntity(retEntity);return red.toEntity(retEntity);}).collect(Collectors.toList());
+		retEntity.setRoutineEndDetail(redEntity);
+		routineEndTotalRepository.save(retEntity);
+		return RoutineEndTotalDto.toDto(retEntity);
 	}
 
 }

--- a/src/main/java/com/project/mog/service/routine/SaveRoutineDto.java
+++ b/src/main/java/com/project/mog/service/routine/SaveRoutineDto.java
@@ -1,0 +1,51 @@
+package com.project.mog.service.routine;
+
+import com.project.mog.repository.routine.RoutineEntity;
+import com.project.mog.repository.routine.SaveRoutineEntity;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class SaveRoutineDto {
+	private long srId;
+	private long exId;
+	private String srName;
+	private long setNumber;
+	private long reps;
+	private long weight;
+	private long setId;
+	
+	public SaveRoutineEntity toEntity(RoutineEntity rEntity) {
+		return SaveRoutineEntity.builder()
+				.exId(exId)
+				.srName(srName)
+				.setNumber(setNumber)
+				.reps(reps)
+				.weight(weight)
+				.routine(rEntity)
+				.build();
+	}
+	
+	
+	
+	public static SaveRoutineDto toDto(SaveRoutineEntity srEntity){
+		if (srEntity==null) return null;
+		return SaveRoutineDto.builder()
+				.srId(srEntity.getSrId())
+				.exId(srEntity.getExId())
+				.srName(srEntity.getSrName())
+				.setNumber(srEntity.getSetNumber())
+				.reps(srEntity.getReps())
+				.weight(srEntity.getWeight())
+				.setId(srEntity.getRoutine().getSetId())
+				.build();
+	}
+}

--- a/src/main/java/com/project/mog/service/users/UsersInfoDto.java
+++ b/src/main/java/com/project/mog/service/users/UsersInfoDto.java
@@ -33,6 +33,7 @@ public class UsersInfoDto {
 	private String email;
 	@Schema(description = "profileImg",example="profileImg.png")
 	private String profileImg;
+	private LocalDateTime regDate;
 	private LocalDateTime updateDate;
 	
 	
@@ -59,6 +60,7 @@ public class UsersInfoDto {
 				.usersName(user.getUsersName())
 				.profileImg(user.getProfileImg())
 				.nickName(user.getNickName())
+				.regDate(user.getRegDate())
 				.updateDate(user.getUpdateDate())
 				.biosDto(BiosDto.toDto(user.getBios()))
 				.build();
@@ -70,6 +72,7 @@ public class UsersInfoDto {
 				.usersName(user.getUsersName())
 				.profileImg(user.getProfileImg())
 				.nickName(user.getNickName())
+				.regDate(user.getRegDate())
 				.updateDate(user.getUpdateDate())
 				.biosDto(BiosDto.toDto(user.getBios()))
 				.build();

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -30,13 +30,13 @@ spring:
   #Spring Data JPA 설정
     jpa:
       hibernate:
-        ddl-auto: update
+        ddl-auto: create
         naming:
           physical-strategy: org.hibernate.boot.model.naming.PhysicalNamingStrategyStandardImpl
       show-sql: true
       properties:
         hibernate:
           format_sql: true
-
+      
 jwttoken:
   secret-key: Nf/vIRqt0/bKThqJ6tOy2M9tqJX+rJxGG9HrZgsBrT4=


### PR DESCRIPTION
1. 루틴 결과 등록 api 구현
- api/v1/routine/{setId}/result로 POST 요청
- body (형식): 
```
{
    "retId":1,
    "tStart":"2025-07-16T14:11:44.2795355",
    "tEnd":"2025-07-16T14:11:44.2795355",
    "routineEndDetails":[
        {
            "srName":"운동이름",
            "setNumber":1,
            "reps":1,
            "weight":100
        },
        {
            "srName":"운동이름",
            "setNumber":2,
            "reps":3,
            "weight":0
        }
    ],
    "routineResult":{
        "muscle":20,
        "kcal":100,
        "reSet":1,
        "setNum":5,
        "volum":10,
        "rouTime":10,
        "exVolum":10
    }
}
```
- 피드백 이후 관련 api 수정 및 entity 수정 예정