### PR TITLE
feat : 루틴 결과 전체 조회 api 구현

### DIFF
--- a/src/main/java/com/project/mog/controller/routine/RoutineController.java
+++ b/src/main/java/com/project/mog/controller/routine/RoutineController.java
@@ -80,4 +80,12 @@ public class RoutineController {
 
 	}
 	
+	@GetMapping("/result")
+	public ResponseEntity<List<RoutineEndTotalDto>> getAllRoutineEndTotals(@RequestHeader("Authorization") String authHeader){
+		String token = authHeader.replace("Bearer ", "");
+		String authEmail = jwtUtil.extractUserEmail(token);
+		List<RoutineEndTotalDto> routineEndTotals = routineService.getAllRoutineEndTotals(authEmail);
+		return ResponseEntity.status(HttpStatus.OK).body(routineEndTotals);
+	}
+	
 }

--- a/src/main/java/com/project/mog/repository/routine/RoutineEndTotalRepository.java
+++ b/src/main/java/com/project/mog/repository/routine/RoutineEndTotalRepository.java
@@ -1,7 +1,13 @@
 package com.project.mog.repository.routine;
 
+import java.util.List;
+
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 
 public interface RoutineEndTotalRepository extends JpaRepository<RoutineEndTotalEntity, Long> {
+
+	@Query(nativeQuery=true,value="SELECT * FROM routineendtotal WHERE setid=?1" )
+	List<RoutineEndTotalEntity> findAllBySetId(long setId);
 
 }

--- a/src/main/java/com/project/mog/repository/routine/RoutineRepository.java
+++ b/src/main/java/com/project/mog/repository/routine/RoutineRepository.java
@@ -14,4 +14,5 @@ public interface RoutineRepository extends JpaRepository<RoutineEntity, Long>{
 
 	@Query(nativeQuery=true,value="SELECT * FROM routinemain WHERE usersid =?1 AND setid=?2")
 	public Optional<RoutineEntity> findByUsersIdAndSetId(Long usersId, Long setId);
+
 }

--- a/src/main/java/com/project/mog/service/routine/RoutineService.java
+++ b/src/main/java/com/project/mog/service/routine/RoutineService.java
@@ -109,6 +109,15 @@ public class RoutineService {
 		routineEndTotalRepository.save(retEntity);
 		return RoutineEndTotalDto.toDto(retEntity);
 	}
+	public List<RoutineEndTotalDto> getAllRoutineEndTotals(String authEmail) {
+		UsersEntity currentUser = usersRepository.findByEmail(authEmail);
+		List<RoutineEntity> routineEntities = routineRepository.findByUsersId(currentUser.getUsersId()).stream().collect(Collectors.toList());
+		List<RoutineEndTotalEntity> allRoutineEndTotals = routineEntities.stream()
+			    .flatMap(routine -> routineEndTotalRepository.findAllBySetId(routine.getSetId()).stream())
+			    .collect(Collectors.toList());
+		System.out.println(allRoutineEndTotals);
+		return allRoutineEndTotals.stream().map(RoutineEndTotalDto::toDto).collect(Collectors.toList());
+	}
 
 
 }


### PR DESCRIPTION
1. 루틴 결과 전체 조회 api 구현
- 추후 데이터 필터링을 위해 RequestBody에 기간 설정 추가 예정
- api/v1/routine/result로 GET 요청