### PR TITLE
feat : RoutineResult null 처리, 카카오 로그인 리팩토링

### DIFF
--- a/src/main/java/com/project/mog/aop/UserAuthorizationAspect.java
+++ b/src/main/java/com/project/mog/aop/UserAuthorizationAspect.java
@@ -35,7 +35,7 @@ public class UserAuthorizationAspect {
 			throw new IllegalArgumentException("유저 정보가 충분하지 않습니다");
 		}
 		UsersEntity targetUser = usersRepository.findById(userId).orElseThrow(()->new RuntimeException("수정할 사용자를 찾을 수 없습니다"));
-		UsersEntity currentUser = usersRepository.findByEmail(authEmail);
+		UsersEntity currentUser = usersRepository.findByEmail(authEmail).orElseThrow(()->new IllegalArgumentException("유효하지 않은 사용자입니다"));
 		
 		if(currentUser.getUsersId()!=userId) {
 			throw new AccessDeniedException("유저 권한이 없습니다");

--- a/src/main/java/com/project/mog/api/KakaoApiClient.java
+++ b/src/main/java/com/project/mog/api/KakaoApiClient.java
@@ -1,0 +1,31 @@
+package com.project.mog.api;
+
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Component;
+import org.springframework.web.client.RestTemplate;
+
+import com.project.mog.service.users.KakaoUser;
+
+@Component
+public class KakaoApiClient {
+	private final RestTemplate restTemplate;
+	
+	public KakaoApiClient() {
+		this.restTemplate = new RestTemplate();
+	}
+	
+	public KakaoUser getUserInfo(String accessToken) {
+		HttpHeaders headers = new HttpHeaders();
+		headers.set("Authorization", "Bearer "+accessToken);
+		
+		HttpEntity<Void> request = new HttpEntity<>(headers);
+		
+		ResponseEntity<KakaoUser> response = restTemplate.exchange("https://kapi.kakao.com/v2/user/me", HttpMethod.GET,
+				request,KakaoUser.class);
+		System.out.println("accessToken authorized");
+		return response.getBody();
+	}
+}

--- a/src/main/java/com/project/mog/config/security/SecurityConfig.java
+++ b/src/main/java/com/project/mog/config/security/SecurityConfig.java
@@ -52,9 +52,11 @@ public class SecurityConfig {
 				.authorizeHttpRequests(auth -> auth.requestMatchers(
 						"/api/v1/users/list",
 						"/api/v1/users/login",
+						"/api/v1/users/login/*",
 						"/api/v1/users/signup",
 						"/api/v1/routine/**",
 						"/api/v1/users/*",
+						"/api/v1/users/email/**",
 						"/swagger-ui/*",
 						"/swagger-resources/**",
 						"/v3/api-docs/**",

--- a/src/main/java/com/project/mog/controller/login/SocialLoginRequest.java
+++ b/src/main/java/com/project/mog/controller/login/SocialLoginRequest.java
@@ -1,0 +1,14 @@
+package com.project.mog.controller.login;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+public class SocialLoginRequest {
+	@Schema(description = "socialType",example="kakao")
+	private String socialType;
+	@Schema(description = "accessToken",example="AccessToken")
+	private String accessToken;
+}

--- a/src/main/java/com/project/mog/controller/routine/RoutineController.java
+++ b/src/main/java/com/project/mog/controller/routine/RoutineController.java
@@ -88,4 +88,12 @@ public class RoutineController {
 		return ResponseEntity.status(HttpStatus.OK).body(routineEndTotals);
 	}
 	
+	@GetMapping("result") //이후 기간 추가해야함(모든 데이터 반환시 서버에 가해지는 부하 고려)
+	public ResponseEntity<List<RoutineEndTotalDto>> getRoutineEndTotal(@RequestHeader("Authorization") String authHeader){
+		String token = authHeader.replace("Bearer ", "");
+		String authEmail = jwtUtil.extractUserEmail(token);
+		List<RoutineEndTotalDto> routineEndTotal = routineService.getRoutineEndTotal(authEmail);
+		return ResponseEntity.status(HttpStatus.OK).body(routineEndTotal);
+	}
+	
 }

--- a/src/main/java/com/project/mog/controller/users/UsersController.java
+++ b/src/main/java/com/project/mog/controller/users/UsersController.java
@@ -20,6 +20,7 @@ import org.springframework.web.bind.annotation.RestController;
 
 import com.project.mog.controller.login.LoginRequest;
 import com.project.mog.controller.login.LoginResponse;
+import com.project.mog.controller.login.SocialLoginRequest;
 import com.project.mog.docs.UsersControllerDocs;
 import com.project.mog.repository.users.UsersEntity;
 import com.project.mog.security.jwt.JwtUtil;
@@ -56,7 +57,10 @@ public class UsersController implements UsersControllerDocs{
 	@GetMapping("/{usersId}")
 	public ResponseEntity<UsersInfoDto> getUser(@PathVariable Long usersId){
 		return usersService.getUser(usersId).map(ResponseEntity::ok).orElse(ResponseEntity.notFound().build());
-				
+	}
+	@GetMapping("/email/{email}")
+	public ResponseEntity<UsersInfoDto> getUserByEmail(@PathVariable String email){
+		return usersService.getUserByEmail(email).map(ResponseEntity::ok).orElse(ResponseEntity.notFound().build());
 	}
 	@Transactional
 	@PutMapping("/update/{usersId}")
@@ -93,6 +97,24 @@ public class UsersController implements UsersControllerDocs{
 											.refreshToken(refreshToken)
 											.build();
 		
+		return ResponseEntity.status(HttpStatus.OK).body(loginResponse);
+	}
+	
+
+	@PostMapping("login/kakao")
+	public ResponseEntity<LoginResponse> socialLogin(@RequestBody SocialLoginRequest request){
+		UsersDto usersDto = usersService.socialLogin(request);
+		long usersId = usersDto.getUsersId();
+		String email = usersDto.getEmail();
+		String accessToken = jwtUtil.generateAccessToken(email);
+		String refreshToken = jwtUtil.generateRefreshToken(email);
+		
+		LoginResponse loginResponse = LoginResponse.builder()
+										.usersId(usersId)
+										.email(email)
+										.accessToken(accessToken)
+										.refreshToken(refreshToken)
+										.build();
 		return ResponseEntity.status(HttpStatus.OK).body(loginResponse);
 	}
 	

--- a/src/main/java/com/project/mog/repository/routine/RoutineEndTotalEntity.java
+++ b/src/main/java/com/project/mog/repository/routine/RoutineEndTotalEntity.java
@@ -53,6 +53,6 @@ public class RoutineEndTotalEntity {
 	
 	@OneToOne(fetch = FetchType.LAZY)
 
-	@JoinColumn(name="rrId",referencedColumnName="rrId",nullable=false)
+	@JoinColumn(name="rrId",referencedColumnName="rrId",nullable=true)
 	private RoutineResultEntity routineResult;
 }

--- a/src/main/java/com/project/mog/repository/routine/RoutineEndTotalRepository.java
+++ b/src/main/java/com/project/mog/repository/routine/RoutineEndTotalRepository.java
@@ -7,6 +7,7 @@ import org.springframework.data.jpa.repository.Query;
 
 public interface RoutineEndTotalRepository extends JpaRepository<RoutineEndTotalEntity, Long> {
 
+
 	@Query(nativeQuery=true,value="SELECT * FROM routineendtotal WHERE setid=?1" )
 	List<RoutineEndTotalEntity> findAllBySetId(long setId);
 

--- a/src/main/java/com/project/mog/repository/users/UsersRepository.java
+++ b/src/main/java/com/project/mog/repository/users/UsersRepository.java
@@ -15,5 +15,5 @@ public interface UsersRepository extends JpaRepository<UsersEntity, Long>{
 	Optional<UsersEntity> findByEmailAndPassword(String email, String password);
 
 	@Query(nativeQuery = true,value="SELECT * FROM USERS WHERE USERS.EMAIL=?1")
-	UsersEntity findByEmail(String email);
+	Optional<UsersEntity> findByEmail(String email);
 }

--- a/src/main/java/com/project/mog/security/UsersDetailService.java
+++ b/src/main/java/com/project/mog/security/UsersDetailService.java
@@ -19,7 +19,7 @@ public class UsersDetailService implements UserDetailsService{
 
 	@Override
 	public UserDetails loadUserByUsername(String email) throws UsernameNotFoundException{
-			UsersEntity users = usersRepository.findByEmail(email);
+			UsersEntity users = usersRepository.findByEmail(email).orElseThrow(()->new IllegalArgumentException("유효하지 않은 사용자입니다"));
 			if(users==null) throw new UsernameNotFoundException("계정을 찾을 수 없습니다");
 			return new UsersDetails(users);
 		

--- a/src/main/java/com/project/mog/service/routine/RoutineResultDto.java
+++ b/src/main/java/com/project/mog/service/routine/RoutineResultDto.java
@@ -43,6 +43,7 @@ public class RoutineResultDto {
 								.muscle(rrEntity.getMuscle())
 								.kcal(rrEntity.getKcal())
 								.reSet(rrEntity.getReSet())
+								.setNum(rrEntity.getSetNum())
 								.volum(rrEntity.getVolum())
 								.rouTime(rrEntity.getRouTime())
 								.exVolum(rrEntity.getExVolum())

--- a/src/main/java/com/project/mog/service/users/KakaoUser.java
+++ b/src/main/java/com/project/mog/service/users/KakaoUser.java
@@ -1,0 +1,42 @@
+package com.project.mog.service.users;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class KakaoUser {
+    private Long id;//카카오의 고유 아이디
+    private String connected_at;
+    private Properties properties;
+    private KakaoAccount kakao_account;
+
+    @Getter @Setter
+    public static class Properties {
+        private String nickname;
+        private String profile_image;
+        private String thumbnail_image;
+    }
+
+    @Getter @Setter
+    public static class KakaoAccount {
+        private Boolean profile_nickname_needs_agreement;
+        private Boolean profile_image_needs_agreement;
+        private Profile profile;
+    }
+
+    @Getter @Setter
+    public static class Profile {
+        private String nickname;
+        private String thumbnail_image_url;
+        private String profile_image_url;
+        private Boolean is_default_image;
+        private Boolean is_default_nickname;
+    }
+}


### PR DESCRIPTION
1. RoutineResult null처리
- 프론트 요청에 따라 RoutineResult null처리 가능하도록 설정
2. 카카오 로그인 리팩토링
- 회원가입한 카카오 사용자 확인 후 로그인 설정
- accessToken을 백엔드에서 확인 및 인증 후 로그인 처리가 필요함에 따라 리팩토링 진행함
- 해당 로그인 과정에 필요한 KakaoApiClient, KakaoUser, service등 추가
- 그 외 필요한 타입 변경 (Optional등)
- api/v1/users/login/kakao로 GET 조회
- body : {socialType, AccessToken}
3. 이메일 조회 api 추가
- api/v1/users/email/{email}로 GET 조회