### PR TITLE
feat : 비밀번호, 아이디 찾기 api 구현 외

### DIFF
--- a/src/main/java/com/project/mog/config/security/SecurityConfig.java
+++ b/src/main/java/com/project/mog/config/security/SecurityConfig.java
@@ -55,7 +55,7 @@ public class SecurityConfig {
 						"/api/v1/users/login/*",
 						"/api/v1/users/signup",
 						"/api/v1/routine/**",
-						"/api/v1/users/*",
+						"/api/v1/users/**",
 						"/api/v1/users/email/**",
 						"/swagger-ui/*",
 						"/swagger-resources/**",

--- a/src/main/java/com/project/mog/controller/auth/EmailFindRequest.java
+++ b/src/main/java/com/project/mog/controller/auth/EmailFindRequest.java
@@ -1,0 +1,12 @@
+package com.project.mog.controller.auth;
+
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+public class EmailFindRequest {
+	private String usersName;
+	private String phoneNum;
+	
+}

--- a/src/main/java/com/project/mog/controller/auth/PasswordCheckRequest.java
+++ b/src/main/java/com/project/mog/controller/auth/PasswordCheckRequest.java
@@ -1,0 +1,10 @@
+package com.project.mog.controller.auth;
+
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+public class PasswordCheckRequest {
+	private String password;
+}

--- a/src/main/java/com/project/mog/controller/auth/PasswordUpdateRequest.java
+++ b/src/main/java/com/project/mog/controller/auth/PasswordUpdateRequest.java
@@ -1,0 +1,11 @@
+package com.project.mog.controller.auth;
+
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+public class PasswordUpdateRequest {
+	private String originPassword;
+	private String newPassword;
+}

--- a/src/main/java/com/project/mog/controller/login/LoginRequest.java
+++ b/src/main/java/com/project/mog/controller/login/LoginRequest.java
@@ -1,11 +1,13 @@
 package com.project.mog.controller.login;
 
 import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.Setter;
 
 @Getter
 @Setter
+@Builder
 public class LoginRequest {
 	@Schema(description = "email",example="test@test.com")
 	private String email;

--- a/src/main/java/com/project/mog/controller/routine/RoutineController.java
+++ b/src/main/java/com/project/mog/controller/routine/RoutineController.java
@@ -73,26 +73,16 @@ public class RoutineController {
 	
 	//루틴 결과 관련 api
 	@PostMapping("{setId}/result")
-
 	public ResponseEntity<RoutineEndTotalDto> createRoutineEndTotal(@RequestBody RoutineEndTotalDto routineEndTotalDto,@PathVariable Long setId){
 		RoutineEndTotalDto routineEndTotal = routineService.createRoutineEndTotal(routineEndTotalDto,setId);
 		return ResponseEntity.status(HttpStatus.CREATED).body(routineEndTotal);
-
-	}
-	
-	@GetMapping("/result")
-	public ResponseEntity<List<RoutineEndTotalDto>> getAllRoutineEndTotals(@RequestHeader("Authorization") String authHeader){
-		String token = authHeader.replace("Bearer ", "");
-		String authEmail = jwtUtil.extractUserEmail(token);
-		List<RoutineEndTotalDto> routineEndTotals = routineService.getAllRoutineEndTotals(authEmail);
-		return ResponseEntity.status(HttpStatus.OK).body(routineEndTotals);
 	}
 	
 	@GetMapping("result") //이후 기간 추가해야함(모든 데이터 반환시 서버에 가해지는 부하 고려)
-	public ResponseEntity<List<RoutineEndTotalDto>> getRoutineEndTotal(@RequestHeader("Authorization") String authHeader){
+	public ResponseEntity<List<RoutineEndTotalDto>> getRoutineEndTotal(@RequestHeader("Authorization") String authHeader, @RequestBody(required = false) RoutineEndTotalRequest routineEndTotalRequest){
 		String token = authHeader.replace("Bearer ", "");
 		String authEmail = jwtUtil.extractUserEmail(token);
-		List<RoutineEndTotalDto> routineEndTotal = routineService.getRoutineEndTotal(authEmail);
+		List<RoutineEndTotalDto> routineEndTotal = routineService.getRoutineEndTotal(authEmail,routineEndTotalRequest);
 		return ResponseEntity.status(HttpStatus.OK).body(routineEndTotal);
 	}
 	

--- a/src/main/java/com/project/mog/controller/routine/RoutineEndTotalRequest.java
+++ b/src/main/java/com/project/mog/controller/routine/RoutineEndTotalRequest.java
@@ -1,0 +1,13 @@
+package com.project.mog.controller.routine;
+
+import java.time.LocalDateTime;
+
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+public class RoutineEndTotalRequest {
+	LocalDateTime startDate;
+	LocalDateTime endDate;
+}

--- a/src/main/java/com/project/mog/repository/routine/RoutineEndTotalRepository.java
+++ b/src/main/java/com/project/mog/repository/routine/RoutineEndTotalRepository.java
@@ -1,5 +1,6 @@
 package com.project.mog.repository.routine;
 
+import java.time.LocalDateTime;
 import java.util.List;
 
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -7,8 +8,10 @@ import org.springframework.data.jpa.repository.Query;
 
 public interface RoutineEndTotalRepository extends JpaRepository<RoutineEndTotalEntity, Long> {
 
-
-	@Query(nativeQuery=true,value="SELECT * FROM routineendtotal WHERE setid=?1" )
+	@Query(nativeQuery=true, value="SELECT * FROM ROUTINEENDTOTAL WHERE SETID=?1")
 	List<RoutineEndTotalEntity> findAllBySetId(long setId);
+	
+	@Query(nativeQuery=true, value="SELECT * FROM ROUTINEENDTOTAL WHERE SETID=?1 AND TSTART<=?3 AND TEND>=?2")
+	List<RoutineEndTotalEntity> findAllBySetIdAndDateBetween(long setId,LocalDateTime startDate, LocalDateTime endDate);
 
 }

--- a/src/main/java/com/project/mog/repository/routine/RoutineRepository.java
+++ b/src/main/java/com/project/mog/repository/routine/RoutineRepository.java
@@ -15,4 +15,5 @@ public interface RoutineRepository extends JpaRepository<RoutineEntity, Long>{
 	@Query(nativeQuery=true,value="SELECT * FROM routinemain WHERE usersid =?1 AND setid=?2")
 	public Optional<RoutineEntity> findByUsersIdAndSetId(Long usersId, Long setId);
 
+	
 }

--- a/src/main/java/com/project/mog/repository/users/UsersEntity.java
+++ b/src/main/java/com/project/mog/repository/users/UsersEntity.java
@@ -49,6 +49,9 @@ public class UsersEntity {
 	@Column(length = 100,nullable = true)
 	private String profileImg;
 	
+	@Column(length=11,nullable=false)
+	private String phoneNum;
+	
 	@Column(nullable=false,updatable = false)
 	private LocalDateTime regDate;
 	@Column(nullable=false)

--- a/src/main/java/com/project/mog/repository/users/UsersRepository.java
+++ b/src/main/java/com/project/mog/repository/users/UsersRepository.java
@@ -7,6 +7,7 @@ import org.springframework.data.jpa.repository.Query;
 
 import com.project.mog.repository.bios.BiosEntity;
 
+
 public interface UsersRepository extends JpaRepository<UsersEntity, Long>{
 
 	Optional<UsersEntity> findById(Long usersId);
@@ -16,4 +17,7 @@ public interface UsersRepository extends JpaRepository<UsersEntity, Long>{
 
 	@Query(nativeQuery = true,value="SELECT * FROM USERS WHERE USERS.EMAIL=?1")
 	Optional<UsersEntity> findByEmail(String email);
+
+	@Query(nativeQuery = true, value="SELECT * FROM USERS WHERE USERS.USERSNAME=?1 AND PHONENUM=?2")
+	Optional<UsersEntity> findByUsersNameAndPhoneNum(String usersName, String phoneNum);
 }

--- a/src/main/java/com/project/mog/service/routine/RoutineEndDetailDto.java
+++ b/src/main/java/com/project/mog/service/routine/RoutineEndDetailDto.java
@@ -1,5 +1,6 @@
 package com.project.mog.service.routine;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.project.mog.repository.routine.RoutineEndDetailEntity;
 import com.project.mog.repository.routine.RoutineEndTotalEntity;
 
@@ -20,6 +21,7 @@ public class RoutineEndDetailDto {
 	private long setNumber;
 	private long reps;
 	private long weight;
+	@JsonIgnore
 	private RoutineEndTotalEntity routineEndTotalEntity;
 	
 	public RoutineEndDetailEntity toEntity(RoutineEndTotalEntity retEntity) {

--- a/src/main/java/com/project/mog/service/routine/RoutineEndTotalDto.java
+++ b/src/main/java/com/project/mog/service/routine/RoutineEndTotalDto.java
@@ -5,7 +5,7 @@ import java.util.List;
 import java.util.stream.Collectors;
 
 import com.fasterxml.jackson.annotation.JsonFormat;
-
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.project.mog.repository.routine.RoutineEndDetailEntity;
 import com.project.mog.repository.routine.RoutineEndTotalEntity;
 import com.project.mog.repository.routine.RoutineEntity;
@@ -23,11 +23,11 @@ import lombok.Setter;
 @AllArgsConstructor
 @Builder
 public class RoutineEndTotalDto {
+	private long id;
 	private long retId;
-
-	@JsonFormat(pattern = "yyyy-MM-dd'T'HH:mm:ss.SSSSSSS")
+	@JsonProperty("tStart")
 	private LocalDateTime tStart;
-	@JsonFormat(pattern = "yyyy-MM-dd'T'HH:mm:ss.SSSSSSS")
+	@JsonProperty("tEnd")
 	private LocalDateTime tEnd;
 	private List<RoutineEndDetailDto> routineEndDetails;
 	private RoutineResultDto routineResult;
@@ -47,6 +47,7 @@ public class RoutineEndTotalDto {
 		}
 		
 		return RoutineEndTotalDto.builder()
+								.id(retEntity.getRoutine().getSetId())
 								.retId(retEntity.getRetId())
 								.tStart(retEntity.getTStart())
 								.tEnd(retEntity.getTEnd())
@@ -56,4 +57,3 @@ public class RoutineEndTotalDto {
 	
 	}
 }
-

--- a/src/main/java/com/project/mog/service/users/UsersDto.java
+++ b/src/main/java/com/project/mog/service/users/UsersDto.java
@@ -36,6 +36,8 @@ public class UsersDto {
 	private String email;
 	@Schema(description = "profileImg",example="profileImg.png")
 	private String profileImg;
+	@Schema(description = "phoneNum", example="01012345678")
+	private String phoneNum;
 	private LocalDateTime regDate;
 	private LocalDateTime updateDate;
 	
@@ -46,6 +48,7 @@ public class UsersDto {
 					.nickName(nickName)
 					.email(email)
 					.profileImg(profileImg)
+					.phoneNum(phoneNum)
 					.regDate(regDate)
 					.updateDate(updateDate)
 					.bios(Optional.ofNullable(biosDto).map(BiosDto::toEntity).orElse(null))
@@ -72,6 +75,7 @@ public class UsersDto {
 				.nickName(uEntity.getNickName())
 				.email(uEntity.getEmail())
 				.profileImg(uEntity.getProfileImg())
+				.phoneNum(uEntity.getPhoneNum())
 				.regDate(uEntity.getRegDate())
 				.updateDate(uEntity.getUpdateDate())
 				.biosDto(BiosDto.toDto(uEntity.getBios()))

--- a/src/main/java/com/project/mog/service/users/UsersInfoDto.java
+++ b/src/main/java/com/project/mog/service/users/UsersInfoDto.java
@@ -2,6 +2,7 @@ package com.project.mog.service.users;
 
 import java.time.LocalDateTime;
 
+import com.project.mog.repository.auth.AuthEntity;
 import com.project.mog.repository.bios.BiosEntity;
 import com.project.mog.repository.users.UsersEntity;
 import com.project.mog.service.auth.AuthDto;
@@ -33,7 +34,8 @@ public class UsersInfoDto {
 	private String email;
 	@Schema(description = "profileImg",example="profileImg.png")
 	private String profileImg;
-
+	@Schema(description = "phoneNum", example="01012345678")
+	private String phoneNum;
 	private LocalDateTime regDate;
 	private LocalDateTime updateDate;
 	
@@ -61,6 +63,7 @@ public class UsersInfoDto {
 				.usersName(user.getUsersName())
 				.profileImg(user.getProfileImg())
 				.nickName(user.getNickName())
+				.phoneNum(user.getPhoneNum())
 				.regDate(user.getRegDate())
 				.updateDate(user.getUpdateDate())
 				.biosDto(BiosDto.toDto(user.getBios()))
@@ -73,6 +76,7 @@ public class UsersInfoDto {
 				.usersName(user.getUsersName())
 				.profileImg(user.getProfileImg())
 				.nickName(user.getNickName())
+				.phoneNum(user.getPhoneNum())
 				.regDate(user.getRegDate())
 				.updateDate(user.getUpdateDate())
 				.biosDto(BiosDto.toDto(user.getBios()))

--- a/src/main/java/com/project/mog/service/users/UsersService.java
+++ b/src/main/java/com/project/mog/service/users/UsersService.java
@@ -12,6 +12,7 @@ import org.springframework.stereotype.Service;
 
 import com.project.mog.annotation.UserAuthorizationCheck;
 import com.project.mog.api.KakaoApiClient;
+import com.project.mog.controller.auth.EmailFindRequest;
 import com.project.mog.controller.login.LoginRequest;
 import com.project.mog.controller.login.LoginResponse;
 import com.project.mog.controller.login.SocialLoginRequest;
@@ -55,12 +56,12 @@ public class UsersService {
 		}
 
 
-		public Optional<UsersInfoDto> getUser(Long usersId) {
-			return usersRepository.findById(usersId).map(uEntity->UsersInfoDto.toDto(uEntity));
+		public UsersInfoDto getUser(Long usersId) {
+			return usersRepository.findById(usersId).map(uEntity->UsersInfoDto.toDto(uEntity)).orElseThrow(()->new IllegalArgumentException("사용자를 찾을 수 없습니다"));
 		}
 		
-		public Optional<UsersInfoDto> getUserByEmail(String email) {
-			return usersRepository.findByEmail(email).map(uEntity->UsersInfoDto.toDto(uEntity));
+		public UsersInfoDto getUserByEmail(String email) {
+			return usersRepository.findByEmail(email).map(uEntity->UsersInfoDto.toDto(uEntity)).orElseThrow(()->new IllegalArgumentException("사용자를 찾을 수 없습니다"));
 		}
 
 		@UserAuthorizationCheck
@@ -76,14 +77,7 @@ public class UsersService {
 		}
 
 		@UserAuthorizationCheck
-		public UsersInfoDto editUser(UsersInfoDto usersInfoDto, Long usersId, String authEmail) {
-//			UsersEntity currentUser = usersRepository.findByEmail(authEmail);
-//			UsersEntity targetUser = usersRepository.findById(usersId).orElseThrow(()->new RuntimeException("수정할 사용자를 찾을 수 없습니다"));
-//			
-//			//권한을 가진 유저의 수정 요청인지 확인
-//			if(currentUser.getUsersId()!=targetUser.getUsersId()) throw new AccessDeniedException("자기 자신만 수정 가능합니다");
-//			
-			
+		public UsersInfoDto editUser(UsersInfoDto usersInfoDto, Long usersId, String authEmail) {		
 			UsersEntity usersEntity =usersRepository.findById(usersId).orElseThrow(()->new IllegalArgumentException(usersId+"가 존재하지 않습니다"));
 			BiosEntity biosEntity = biosRepository.findByUser(usersEntity);
 			
@@ -121,6 +115,28 @@ public class UsersService {
 			}
 			
 			return null;
+		}
+
+
+		public UsersDto checkPassword(String authEmail, String password) {
+			UsersEntity usersEntity = usersRepository.findByEmailAndPassword(authEmail, password).orElseThrow(()->new IllegalArgumentException("사용자를 찾을 수 없습니다"));
+			return UsersDto.toDto(usersEntity);
+			
+		}
+
+
+		
+		public UsersDto editPassword(String authEmail, String originPassword, String newPassword) {
+			UsersEntity usersEntity = usersRepository.findByEmailAndPassword(authEmail, originPassword).orElseThrow(()->new IllegalArgumentException("사용자를 찾을 수 없습니다"));
+			AuthEntity authEntity = usersEntity.getAuth();
+			authEntity.setPassword(newPassword);
+			return UsersDto.toDto(usersEntity);
+		}
+
+
+		public UsersInfoDto getUserByRequest(EmailFindRequest emailFindRequest) {
+			UsersEntity usersEntity = usersRepository.findByUsersNameAndPhoneNum(emailFindRequest.getUsersName(),emailFindRequest.getPhoneNum()).orElseThrow(()->new IllegalArgumentException("사용자를 찾을 수 없습니다"));
+			return UsersInfoDto.toDto(usersEntity);
 		}
 
 

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -30,7 +30,7 @@ spring:
   #Spring Data JPA 설정
     jpa:
       hibernate:
-        ddl-auto: create
+        ddl-auto: update
         naming:
           physical-strategy: org.hibernate.boot.model.naming.PhysicalNamingStrategyStandardImpl
       show-sql: true


### PR DESCRIPTION
1. 이메일 단일 회원 조회 api
- api/v1/users/email/{email}로 GET 요청

2. 비밀번호 확인 api
- api/v1/users/auth/password/check로 GET 요청
- body: {password}

3. 비밀번호 변경 api
- api/v1/users/auth/password/update로 PUT 요청
- body: {originPassword, newPassword}

4. 아이디 찾기 api
- api/v1/users/auth/email/find로 GET 요청
- body: {usersName, phoneNum}

5. 루틴 결과 전체 조회에 기간 추가
- 전체 조회시 body 없음
- 기간 내 전체 조회시 body: {startDate, endDate} LocalDateTime 형식으로 요청

6. 그 외 리팩토링 및 이슈 해결
- UserEntity에 phoneNum 필드 추가
- RoutineEndTotalDto에 중복 tStart, tEnd 반환 이슈 해결
- 단일조회 api, 단일조회 api(이메일) 간 경로 충돌 이슈 해결
- RoutineEndTotalDto에 routinemain의 setid 추가 => 프론트 요청에 따라 setId -> id로 네이밍 변경